### PR TITLE
Fix the campaign schedule selection.

### DIFF
--- a/app/src/core/campaigns/expert/EditCampaignController.js
+++ b/app/src/core/campaigns/expert/EditCampaignController.js
@@ -16,6 +16,12 @@ define(['./module', 'moment'], function (module, moment) {
           return ;
         }
 
+      $scope.campaignScopeHelper = {
+        campaignDateRange : {startDate: moment(), endDate: moment().add(20, 'days')},
+        schedule : ""
+      };
+      $log.debug('Expert.EditCampaignController called !');
+
 
       function initView() {
         $scope.moreGoals = false;
@@ -23,22 +29,19 @@ define(['./module', 'moment'], function (module, moment) {
         $scope.adGroups = DisplayCampaignService.getAdGroupValues();
         $scope.inventorySources = DisplayCampaignService.getInventorySources();
         $scope.goalSelections = DisplayCampaignService.getGoalSelections();
-        $scope.defaultGoalSelection = _.find(DisplayCampaignService.getGoalSelections(), {"default":true});
+        $scope.campaignScopeHelper.defaultGoalSelection = _.find(DisplayCampaignService.getGoalSelections(), {"default":true});
         updateGoalSelectionsCount();
         $scope.locations = DisplayCampaignService.getLocations();
 
-        $scope.locationSelector = $scope.locations.length ? "custom" : "";
-        $scope.schedule = $scope.campaign.start_date !== null ? "custom" : "";
+        $scope.campaignScopeHelper.locationSelector = $scope.locations.length ? "custom" : "";
+        $scope.campaignScopeHelper.schedule = $scope.campaign.start_date !== null ? "custom" : "";
         if ($scope.campaign.start_date !== null && $scope.campaign.end_date !== null) {
-          $scope.campaignDateRange = {
+          $scope.campaignScopeHelper.campaignDateRange = {
             startDate: moment($scope.campaign.start_date),
             endDate: moment($scope.campaign.end_date)
           };
         }
       }
-
-      $scope.campaignDateRange = {startDate: moment(), endDate: moment().add(20, 'days')};
-      $log.debug('Expert.EditCampaignController called !');
 
       CampaignPluginService.getCampaignTemplate("com.mediarithmics.campaign.display", "default-template").then(function (template) {
         // TODO load the campaign (no effect if already in cache or if this is a temporary id)
@@ -120,7 +123,7 @@ define(['./module', 'moment'], function (module, moment) {
         $scope.updateDefaultGoalSelection = function () {
           
           _.forEach(DisplayCampaignService.getGoalSelections(), function(gs) {gs.default=false; return;})
-          $scope.defaultGoalSelection.default=true
+          $scope.campaignScopeHelper.defaultGoalSelection.default = true;
           return ;
 
         }
@@ -154,7 +157,7 @@ define(['./module', 'moment'], function (module, moment) {
           }
           DisplayCampaignService.removeLocation(elem.id);
           if (!$scope.locations.length) {
-            $scope.locationSelector = "";
+            $scope.campaignScopeHelper.locationSelector = "";
           }
 
         };
@@ -204,9 +207,9 @@ define(['./module', 'moment'], function (module, moment) {
 
           // Save button
         $scope.save = function () {
-          if ($scope.schedule === 'custom') {
-            $scope.campaign.start_date = $scope.campaignDateRange.startDate.valueOf();
-            $scope.campaign.end_date = $scope.campaignDateRange.endDate.valueOf();
+          if ($scope.campaignScopeHelper.schedule === 'custom') {
+            $scope.campaign.start_date = $scope.campaignScopeHelper.campaignDateRange.startDate.valueOf();
+            $scope.campaign.end_date = $scope.campaignScopeHelper.campaignDateRange.endDate.valueOf();
           } else {
             $scope.campaign.start_date = null;
             $scope.campaign.end_date = null;

--- a/app/src/core/campaigns/expert/edit-campaign.html
+++ b/app/src/core/campaigns/expert/edit-campaign.html
@@ -42,26 +42,26 @@
 
     <!-- Schedule -->
     <div mcs-form-group="select" label-for="schedule" label-text="Schedule">
-      <select ng-model="$parent.schedule" class="form-control" id="schedule">
+      <select ng-model="campaignScopeHelper.schedule" class="form-control" id="schedule">
         <option value="">Ongoing (no end date)</option>
         <option value="custom" ng-selected="campaign.start_date != null ? 'selected' : ''">Custom</option>
       </select>
-      <input ng-show="$parent.schedule === 'custom'"
+      <input ng-show="campaignScopeHelper.schedule === 'custom'"
              type="daterange"
              class="form-control range"
-             ng-model="$parent.campaignDateRange"
+             ng-model="campaignScopeHelper.campaignDateRange"
              format="L"/>
     </div>
 
     <!-- Location -->
     <div mcs-form-group="select" label-for="location" label-text="Location">
-      <select class="form-control" id="location" ng-model="$parent.locationSelector">
+      <select class="form-control" id="location" ng-model="campaignScopeHelper.locationSelector">
         <option value="" ng-show="!locations.length">Worldwide</option>
         <option value="custom" ng-selected="locations.length ? 'selected' : ''">Custom</option>
       </select>
     </div>
     <div>
-      <div ng-show="locationSelector == 'custom'" ng-include="'src/core/location/choose-custom-location.html'"></div>
+      <div ng-show="campaignScopeHelper.locationSelector == 'custom'" ng-include="'src/core/location/choose-custom-location.html'"></div>
       <table class="fragment-list-keyword-list" ng-show="locations.length">
         <thead>
         <tr>
@@ -188,7 +188,7 @@
             {{source.goal_name}}
           </td>
           <td > 
-            <input type="radio" name="default-goal-selection" ng-checked="source.default" ng-value="source" ng-model="$parent.defaultGoalSelection"  ng-change="updateDefaultGoalSelection()"/>
+            <input type="radio" name="default-goal-selection" ng-checked="source.default" ng-value="source" ng-model="campaignScopeHelper.defaultGoalSelection"  ng-change="updateDefaultGoalSelection()"/>
           </td>
           <td class="actions">
             <button class="mics-btn mics-btn-delete" ng-click="removeGoalSelection(source)">Delete</button>


### PR DESCRIPTION
The angular 1.2 -> 1.3 migration broke the schedule selection : calling
$parent wasn't a good idea and the scopes in angular can be surprising
without a wrapper object.
In this case, instead of replacing $parent.schedule with
$parent.$parent.schedule, I used a wrapper object to fix the issue.