### PR TITLE
Fix Go Back When Just Logged In

### DIFF
--- a/app/src/core/login/MainController.js
+++ b/app/src/core/login/MainController.js
@@ -4,6 +4,9 @@ define(['./module', "autofill-event"], function (module) {
   module.controller('core/login/MainController', [
     '$scope', '$location', '$log', '$rootScope', 'jquery', 'core/common/auth/AuthenticationService', 'core/common/auth/Session', 'core/login/constants',
     function($scope, $location, $log, $rootScope, $, AuthenticationService, Session, LoginConstants) {
+      if (Session.isInitialized()) {
+        $location.path("/campaigns")
+      }
       $scope.user = {email:"", password:""};
 
       setTimeout(function() {


### PR DESCRIPTION
When the user logs in and tries to go back to the log in page without logging out, we make him stay on the home page.