### PR TITLE
CSR-27: display the campaign location.

### DIFF
--- a/app/src/core/campaigns/expert/edit-campaign.html
+++ b/app/src/core/campaigns/expert/edit-campaign.html
@@ -78,8 +78,14 @@
           <td>
             {{location.type}}
           </td>
-          <td mcs-location="location">
+          <td mcs-location="location" ng-if="location.type == 'POSTAL_CODE'">
             {{location.postal_code}}: {{getLocationDescriptor(locationList)}}
+          </td>
+          <td mcs-location="location" ng-if="location.type == 'GEONAME'">
+            {{location.country}}:{{location.admin1}}:{{location.admin2}}
+          </td>
+          <td mcs-location="location" ng-if="location.type == 'URBAN_AREA'">
+            {{location.urban_area_code}}
           </td>
           <td class="actions">
             <button class="mics-btn mics-btn-delete" ng-click="deleteLocation(location)">Delete</button>

--- a/app/src/core/location/AddPostalCodeListController.js
+++ b/app/src/core/location/AddPostalCodeListController.js
@@ -26,6 +26,7 @@ define(['./module'], function (module) {
           postalCodeAdded = $scope.addedPostalCodes[i];
           $scope.$emit("mics-location:postal-code-added", {
             id: IdGenerator.getId(),
+            type: 'POSTAL_CODE',
             country: $scope.input.country,
             postal_code : postalCodeAdded
           });

--- a/app/src/core/location/LocationDirective.js
+++ b/app/src/core/location/LocationDirective.js
@@ -12,9 +12,10 @@ define(['./module'], function (module) {
             this.setup = function (location) {
 
               $scope.$watch(location, function (newValue, oldValue, scope) {
-                if (!newValue) {
+                if (!newValue || !newValue.postal_code) {
                   return;
                 }
+                // TODO handle more than postal_code
                 var locationList = Restangular.one("geoname", newValue.country).all(newValue.postal_code);
                 $scope.locationList = locationList.getList().$object;
               });


### PR DESCRIPTION
If the custom location of a campaign is not a POSTAL_CODE but a GEONAME,
we will just display a ":". This patch updates the page to at least
display the raw country:admin1:admin2 codes (same thing for URBAN_AREA
and its urban_area_code).