### PR TITLE
Handle correctly goal selections on display campaigns

### DIFF
--- a/app/src/core/campaigns/DisplayCampaignContainer.js
+++ b/app/src/core/campaigns/DisplayCampaignContainer.js
@@ -366,7 +366,11 @@ define(['./module'], function (module) {
           $log.info("saving goalSelection", goalSelection.id);
           var promise;
           if ((goalSelection.id && goalSelection.id.indexOf('T') === -1) || (typeof(goalSelection.modified) !== "undefined")) {
-            promise = goalSelection.put();
+            //  promise = goalSelection.put();
+            // we don't handle updates on goal selections for the moment
+            var deferred = $q.defer();
+            promise = deferred.promise;
+            deferred.resolve();
 
           } else {
             promise = Restangular


### PR DESCRIPTION
There was an issue when saving campaign : If goal selection was set, it
put an empty object on the REST API which result to a an empty goal
selection, causing troubles in attributions (basically no attribution at
all...)