### PR TITLE
Add missing dependency shim.

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -74,6 +74,7 @@ require.config({
     'js-xlsx': ['angular', 'file-saver'],
     // Navigator configuration
     'core/configuration': ['angular'],
+    'lvlUuid':['angular'],
     'lvl.directives.dragdrop':['lvlUuid']
   },
   deps: ['app']


### PR DESCRIPTION
`lvl-uuid` uses the global angular object but it wasn't declared.