### PR TITLE
Display audit details.

### DIFF
--- a/app/src/core/adgroups/adGroupStatusTemplate.html
+++ b/app/src/core/adgroups/adGroupStatusTemplate.html
@@ -1,5 +1,5 @@
 <div class="updatable-item-status updatable-item-status-{{adGroup.status}}" dropdown>
-  <button class="updatable-item-status-state mics-btn btn-xs dropdown-toggle">
+  <button class="updatable-item-status-state mics-btn btn-xs dropdown-toggle" dropdown-toggle>
     <span></span>
     {{adGroup.status}}
     &nbsp;

--- a/app/src/core/adgroups/adStatusTemplate.html
+++ b/app/src/core/adgroups/adStatusTemplate.html
@@ -1,5 +1,5 @@
 <div class="updatable-item-status updatable-item-status-{{ad.status}}" dropdown>
-  <button class="updatable-item-status-state mics-btn btn-xs dropdown-toggle">
+  <button class="updatable-item-status-state mics-btn btn-xs dropdown-toggle" dropdown-toggle>
     <span></span>
     {{ad.status}}
     &nbsp;

--- a/app/src/core/adgroups/choose-ads.html
+++ b/app/src/core/adgroups/choose-ads.html
@@ -3,7 +3,7 @@
     <div class="form-group">
       <div class="row">
         <div class="col-lg-6">
-          <div class="dropdown">
+          <div class="dropdown" dropdown>
             <button ng-click="setAdTypeToDisplayAd()" class="mics-btn mics-btn-add" dropdown-toggle type="button">
               Add Display Ads
             </button>
@@ -19,7 +19,7 @@
         </div>
 
         <div class="col-lg-6">
-          <div class="dropdown">
+          <div class="dropdown" dropdown>
             <button ng-click="setAdTypeToVideoAd()" class="mics-btn mics-btn-add" dropdown-toggle type="button">
               Add Video Ads
             </button>

--- a/app/src/core/bidOptimizer/choose-bid-optimizer.html
+++ b/app/src/core/bidOptimizer/choose-bid-optimizer.html
@@ -1,6 +1,6 @@
 <div ng-controller="core/bidOptimizer/ChooseBidOptimizerController">
-<div class="dropdown">
-  <button class="mics-btn mics-btn-add" dropdown-toggle type="button">
+<div class="dropdown" uib-dropdown>
+  <button class="mics-btn mics-btn-add dropdown-toggle" uib-dropdown-toggle type="button">
     change
   </button>
   <ul class="dropdown-menu" role="menu" aria-labelledby="change bid optimizer">

--- a/app/src/core/bidOptimizer/view.all.html
+++ b/app/src/core/bidOptimizer/view.all.html
@@ -5,7 +5,7 @@
     </div>
     <div class="mics-table-toolbar">
       <div class ="col-md-6">
-        <div class="dropdown">
+        <div class="dropdown" dropdown>
           <a class="mics-btn mics-btn-add" ng-click="createBidOptimizer()">
             New Bid Optimizer
           </a>

--- a/app/src/core/campaigns/campaignStatusTemplate.html
+++ b/app/src/core/campaigns/campaignStatusTemplate.html
@@ -1,5 +1,5 @@
 <div class="updatable-item-status updatable-item-status-{{campaign.status}}" dropdown>
-  <button class="updatable-item-status-state mics-btn btn-xs dropdown-toggle">
+  <button class="updatable-item-status-state mics-btn btn-xs dropdown-toggle" dropdown-toggle>
     <span></span>
     {{campaign.status}}
     &nbsp;

--- a/app/src/core/campaigns/list-display-campaigns.html
+++ b/app/src/core/campaigns/list-display-campaigns.html
@@ -17,7 +17,7 @@
                 <form class="form-inline pull-right" role="form">
                     <input type="daterange" ng-model="reportDateRange" class="form-control range" format="L" ranges="reportDefaultDateRanges" opens="'left'">
                 </form>
-                <div class="dropdown pull-right">
+                <div class="dropdown pull-right" dropdown>
                     <button class="btn btn-default" dropdown-toggle type="button">Export <span class="caret"></span></button>
                     <ul class="dropdown-menu" role="menu" aria-labelledby="Choose Export Format">
                         <li role="presentation"><a role="menuitem" tabindex="-1" ng-click="export('xlsx')">Excel (.xlsx)</a></li>

--- a/app/src/core/campaigns/list-email-campaigns.html
+++ b/app/src/core/campaigns/list-email-campaigns.html
@@ -3,7 +3,7 @@
     <div class="campaign-list-heading">
       <h1>
         Email Campaigns
-        <div class="dropdown">
+        <div class="dropdown" dropdown>
           <!--TODO button export disable because not implement yet -->
           <button class="mics-btn mics-btn-finish btn-xs" dropdown-toggle type="button" disabled>Export</button>
           <ul class="dropdown-menu" role="menu" aria-labelledby="Choose Export Format">

--- a/app/src/core/campaigns/report/show-report.html
+++ b/app/src/core/campaigns/report/show-report.html
@@ -31,8 +31,8 @@
             <input type="daterange" ng-model="reportDateRange" class="form-control range" format="L"
                    ranges="reportDefaultDateRanges" opens="'left'">
           </form>
-          <div class="dropdown pull-right">
-            <button class="btn btn-default" dropdown-toggle type="button">Export <span class="caret"></span></button>
+          <div class="dropdown pull-right" dropdown>
+            <button class="btn btn-default dropdown-toggle" dropdown-toggle type="button">Export <span class="caret"></span></button>
             <ul class="dropdown-menu" role="menu" aria-labelledby="Choose Export Format">
               <li role="presentation"><a role="menuitem" tabindex="-1" ng-click="export('xlsx')">Excel (.xlsx)</a></li>
               <!--<li role="presentation"><a role="menuitem" tabindex="-1" ng-click="export('csv')">CSV</a></li>-->

--- a/app/src/core/creatives/plugins/display-ad/common/AuditStatus.inc.html
+++ b/app/src/core/creatives/plugins/display-ad/common/AuditStatus.inc.html
@@ -3,10 +3,29 @@
     <h3>Audit Status</h3>
     <div class="row">
       <div class="col-xs-2">
-        <div class="status failed" ng-show="displayAd.audit_status == 'AUDIT_FAILED'">Failed</div>
-        <div class="status success" ng-show="displayAd.audit_status == 'AUDIT_PASSED'">Success</div>
-        <div class="status pending" ng-show="displayAd.audit_status == 'AUDIT_PENDING'">Pending</div>
-        <div class="status partially-passed" ng-show="displayAd.audit_status == 'AUDIT_PARTIALLY_PASSED'">Partially Passed</div>
+        <div
+           popover-title="Audits details"
+           uib-popover-template="'audit-status-inc-detail-popover'"
+           popover-trigger="click"
+           popover-placement="right"
+           class="show-details-button"
+           >
+           <div class="status failed" ng-show="displayAd.audit_status == 'AUDIT_FAILED'">Failed</div>
+           <div class="status success" ng-show="displayAd.audit_status == 'AUDIT_PASSED'">Success</div>
+           <div class="status pending" ng-show="displayAd.audit_status == 'AUDIT_PENDING'">Pending</div>
+           <div class="status partially-passed" ng-show="displayAd.audit_status == 'AUDIT_PARTIALLY_PASSED'">Partially Passed</div>
+        </div>
+        <script id="audit-status-inc-detail-popover" type="text/ng-template">
+          <div class="detail-popover">
+            <ul>
+              <li ng-repeat="audit in audits">
+                {{audit.display_network}}: <span class="status {{audit.status}}">{{audit.status}}</span><br>
+                <span ng-show="audit.feedback">({{audit.feedback}})<br></span>
+                Last update {{audit.date|date:'short'}}<br>
+              </li>
+            </ul>
+          </div>
+        </script>
       </div>
       <div class="col-xs-2">
         <div ng-repeat="action in displayAd.available_user_audit_actions">

--- a/app/src/core/goals/edit.one.html
+++ b/app/src/core/goals/edit.one.html
@@ -51,7 +51,7 @@
     </table>
 
 
-    <div class="dropdown">
+    <div class="dropdown" dropdown>
       <button class="mics-btn mics-btn-add" type="button" dropdown-toggle>
         Add Attribution model
         <!-- <span class="caret"></span> -->

--- a/app/src/core/goals/report/show-report.html
+++ b/app/src/core/goals/report/show-report.html
@@ -30,7 +30,7 @@
                     <input type="daterange" ng-model="reportDateRange" class="form-control range" format="L"
                            ranges="reportDefaultDateRanges" opens="'left'">
                 </form>
-                <!-- div class="dropdown pull-right">
+                <!-- div class="dropdown pull-right" dropdown>
                     <button class="btn btn-default" dropdown-toggle type="button">Export <span class="caret"></span></button>
                     <ul class="dropdown-menu" role="menu" aria-labelledby="Choose Export Format">
                         <li role="presentation"><a role="menuitem" tabindex="-1" ng-click="export('xlsx')">Excel (.xlsx)</a></li>

--- a/app/src/core/goals/view.all.html
+++ b/app/src/core/goals/view.all.html
@@ -5,7 +5,7 @@
     </div>
     <div class="mics-table-toolbar">
       <div class ="col-md-6">
-        <div class="dropdown">
+        <div class="dropdown" dropdown>
           <button class="mics-btn mics-btn-add" type="button" ng-click="createGoal()">
             New goal
             <!-- <span class="caret"></span> -->

--- a/app/src/core/keywords/view.all.html
+++ b/app/src/core/keywords/view.all.html
@@ -5,7 +5,7 @@
     </div>
     <div class="mics-table-toolbar">
       <div class ="col-md-6">
-        <div class="dropdown">
+        <div class="dropdown" dropdown>
           <a href="#/{{organisationId}}/library/keywordslists/new" class="mics-btn mics-btn-add">
             New Keywords List
           </a>

--- a/app/src/core/layout/header/navbar/navigator-navbar/navigator-navbar.html
+++ b/app/src/core/layout/header/navbar/navigator-navbar/navigator-navbar.html
@@ -29,7 +29,7 @@
       </ul>
 
       <ul class="nav navbar-nav navbar-right">
-        <li class="dropdown">
+        <li class="dropdown" dropdown>
           <a ng-hide="workspaces.length > 1" href="#" class="mcs-workspace-label">{{currentOrganisation}}</a>
           <a ng-show="workspaces.length > 1" href="#" class="mcs-workspace-label" dropdown-toggle>{{currentOrganisation}}
             <b class="caret"></b></a>
@@ -39,7 +39,7 @@
             </li>
           </ul>
         </li>
-        <li class="dropdown">
+        <li class="dropdown" dropdown>
           <img dropdown-toggle src="./images/user.svg">
           <ul class="dropdown-menu">
             <li><p>{{user.email}}</p></li>

--- a/app/src/core/placementlists/view.all.html
+++ b/app/src/core/placementlists/view.all.html
@@ -5,7 +5,7 @@
     </div>
     <div class="mics-table-toolbar">
       <div class ="col-md-6">
-        <div class="dropdown">
+        <div class="dropdown" dropdown>
           <a class="mics-btn mics-btn-add" href="#/{{organisationId}}/library/placementlists/new">
             New Placement List
           </a>

--- a/app/src/core/queries/view.all.html
+++ b/app/src/core/queries/view.all.html
@@ -5,7 +5,7 @@
     </div>
     <div class="mics-table-toolbar">
       <div class ="col-md-6">
-        <div class="dropdown">
+        <div class="dropdown" dropdown>
           <button class="mics-btn mics-btn-add" type="button" ng-click="createQuery()">
             New Query
             <!-- <span class="caret"></span> -->

--- a/app/src/core/scenarios/edit.one.html
+++ b/app/src/core/scenarios/edit.one.html
@@ -39,7 +39,7 @@
     </table>
 
 
-    <div class="dropdown">
+    <div class="dropdown" dropdown>
       <button class="mics-btn mics-btn-add" type="button" dropdown-toggle>
         Add Input
         <!-- <span class="caret"></span> -->
@@ -55,7 +55,7 @@
     <br />
     <br />
     <h3>Workflow</h3>
-      <div class="dropdown">
+      <div class="dropdown" dropdown>
           <button class="mics-btn mics-btn-add" type="button" dropdown-toggle>
               Add Node
               <!-- <span class="caret"></span> -->

--- a/app/src/core/scenarios/inputs/inputStatusTemplate.html
+++ b/app/src/core/scenarios/inputs/inputStatusTemplate.html
@@ -1,5 +1,5 @@
 <div class="updatable-item-status updatable-item-status-{{input.status}}" dropdown>
-  <button  class="updatable-item-status-state mics-btn btn-xs dropdown-toggle">
+  <button  class="updatable-item-status-state mics-btn btn-xs dropdown-toggle" dropdown-toggle>
     <span></span>
     {{input.status}}
     &nbsp;

--- a/app/src/core/scenarios/scenarioStatusTemplate.html
+++ b/app/src/core/scenarios/scenarioStatusTemplate.html
@@ -1,5 +1,5 @@
 <div class="updatable-item-status updatable-item-status-{{scenario.status}}" dropdown >
-  <button class="updatable-item-status-state mics-btn btn-xs dropdown-toggle">
+  <button class="updatable-item-status-state mics-btn btn-xs dropdown-toggle" dropdown-toggle>
     <span></span>
     {{scenario.status}}
     &nbsp;

--- a/app/src/core/scenarios/view.all.html
+++ b/app/src/core/scenarios/view.all.html
@@ -5,7 +5,7 @@
     </div>
     <div class="mics-table-toolbar">
       <div class ="col-md-6">
-        <div class="dropdown">
+        <div class="dropdown" dropdown>
           <button class="mics-btn mics-btn-add" type="button" ng-click="createScenario()">
             New Scenario
             <!-- <span class="caret"></span> -->

--- a/app/src/core/usergroups/view.all.html
+++ b/app/src/core/usergroups/view.all.html
@@ -5,7 +5,7 @@
     </div>
     <div class="mics-table-toolbar">
       <div class ="col-md-6">
-        <div class="dropdown">
+        <div class="dropdown" dropdown>
           <button class="mics-btn mics-btn-add" type="button" dropdown-toggle>
             New User Group
             <!-- <span class="caret"></span> -->

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1855,20 +1855,32 @@ a.category-item {
     color: #FFFFFF;
   }
 
-  .failed {
+  .failed, .AUDIT_FAILED, .AUDIT_FAILURE {
     background-color: #FE5858;
   }
 
-  .success {
+  .success, .AUDIT_PASSED, .AUDIT_SUCCESS {
     background-color: #00AD68;
   }
 
-  .partially-passed {
+  .partially-passed, .AUDIT_PARTIALLY_PASSED {
     background-color: #092f56;
   }
 
-  .pending {
+  .pending, .AUDIT_PENDING {
     background-color: #FE8F10;
+  }
+
+  .show-details-button {
+    display: inline-block;
+    cursor: help;
+  }
+
+  .detail-popover {
+    min-width: 400px;
+    .status {
+      font-size: $font-size-base;
+    }
   }
 }
 

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "es5-shim": "~2.1.0",
     "jquery": "~1.10.2",
     "jquery-cookie": "1.4.0",
-    "angular-bootstrap": "0.11.0",
+    "angular-bootstrap": "0.14.3",
     "restangular": "1.4.0",
     "async": "0.2.10",
     "plupload": "2.1.1",


### PR DESCRIPTION
When an audit doesn't go as planned, navigator doesn't show us why (or
at least hints). This commit adds a popover to display individual audit
status with the audit message if any.

I also upgraded angular-bootstrap (0.11.0 -> 0.14.3) to have the new
`uib-popover-template` attribute.