### PR TITLE
Improve campaign report performances.

### DIFF
--- a/app/src/core/campaigns/report/CampaignReportController.js
+++ b/app/src/core/campaigns/report/CampaignReportController.js
@@ -39,9 +39,13 @@ define(['./module', 'lodash'], function (module, _) {
       $scope.adPerformance = data;
     });
 
-    CampaignAnalyticsReportService.mediaPerformance(campaignId, $scope.hasCpa, "-click_count", 30).then(function (data) {
-      $scope.mediaPerformance = data;
-    });
+    // For unspeakable reasons (and hopefully soon-to-be-fixed ones) this triggers a huuuuge boost.
+    // I'll work on these, please continue my combat if I fall.
+    setTimeout(function () {
+      CampaignAnalyticsReportService.mediaPerformance(campaignId, $scope.hasCpa, "-click_count", 30).then(function (data) {
+        $scope.mediaPerformance = data;
+      });
+    }, 500);
 
     CampaignAnalyticsReportService.kpi(campaignId, $scope.hasCpa).then(function (data) {
       $scope.kpis = data;

--- a/app/src/core/campaigns/report/show-report.html
+++ b/app/src/core/campaigns/report/show-report.html
@@ -111,19 +111,19 @@
               <tr>
                 <th ng-click="sortAdsBy('status')" class="status">
                   Status
-                  <span ng-show="orderBy == 'status'"><span ng-show="!reverseSort">▼</span><span ng-show="reverseSort">▲</span></span>
+                  <span ng-show="orderBy == 'status'"><span ng-show="reverseSort">▼</span><span ng-show="!reverseSort">▲</span></span>
                 </th>
                 <th ng-click="sortAdsBy('name')">
                   Name
-                  <span ng-show="orderBy == 'name'"><span ng-show="!reverseSort">▼</span><span ng-show="reverseSort">▲</span></span>
+                  <span ng-show="orderBy == 'name'"><span ng-show="reverseSort">▼</span><span ng-show="!reverseSort">▲</span></span>
                 </th>
                 <th ng-click="sortAdsBy('format')">
                   Format
-                  <span ng-show="orderBy == 'format'"><span ng-show="!reverseSort">▼</span><span ng-show="reverseSort">▲</span></span>
+                  <span ng-show="orderBy == 'format'"><span ng-show="reverseSort">▼</span><span ng-show="!reverseSort">▲</span></span>
                 </th>
                 <th ng-click="sortAdsBy(info.key)" class="metrics" ng-repeat="info in ads[0].info">
                   {{ adPerformance.getMetricName(info.key) }}
-                  <span ng-show="orderBy == info.key"><span ng-show="!reverseSort">▼</span><span ng-show="reverseSort">▲</span></span>
+                  <span ng-show="orderBy == info.key"><span ng-show="reverseSort">▼</span><span ng-show="!reverseSort">▲</span></span>
                 </th>
               </tr>
               </thead>
@@ -166,15 +166,15 @@
               <tr>
                 <th class="status" ng-click="sortAdGroupsBy('status')">
                   Status
-                  <span ng-show="orderBy == 'status'"><span ng-show="!reverseSort">▼</span><span ng-show="reverseSort">▲</span></span>
+                  <span ng-show="orderBy == 'status'"><span ng-show="reverseSort">▼</span><span ng-show="!reverseSort">▲</span></span>
                 </th>
                 <th ng-click="sortAdGroupsBy('name')">
                   Name
-                  <span ng-show="orderBy == 'name'"><span ng-show="!reverseSort">▼</span><span ng-show="reverseSort">▲</span></span>
+                  <span ng-show="orderBy == 'name'"><span ng-show="reverseSort">▼</span><span ng-show="!reverseSort">▲</span></span>
                 </th>
                 <th ng-click="sortAdGroupsBy(info.key)" class="metrics" ng-repeat="info in adGroups[0].info">
                   {{ adPerformance.getMetricName(info.key) }}
-                  <span ng-show="orderBy == info.key"><span ng-show="!reverseSort">▼</span><span ng-show="reverseSort">▲</span></span>
+                  <span ng-show="orderBy == info.key"><span ng-show="reverseSort">▼</span><span ng-show="!reverseSort">▲</span></span>
                 </th>
               </tr>
               </thead>
@@ -204,11 +204,11 @@
               <tr>
                 <th ng-click="sortSitesBy('name')">
                   Name
-                  <span ng-show="orderBy == 'name'"><span ng-show="!reverseSort">▼</span><span ng-show="reverseSort">▲</span></span>
+                  <span ng-show="orderBy == 'name'"><span ng-show="reverseSort">▼</span><span ng-show="!reverseSort">▲</span></span>
                 </th>
                 <th ng-click="sortSitesBy(info.key)" class="metrics" ng-repeat="info in sites[0].info">
                   {{ adPerformance.getMetricName(info.key) }}
-                  <span ng-show="orderBy == info.key"><span ng-show="!reverseSort">▼</span><span ng-show="reverseSort">▲</span></span>
+                  <span ng-show="orderBy == info.key"><span ng-show="reverseSort">▼</span><span ng-show="!reverseSort">▲</span></span>
                 </th>
               </tr>
               </thead>

--- a/app/src/core/campaigns/report/show-report.html
+++ b/app/src/core/campaigns/report/show-report.html
@@ -7,7 +7,7 @@
           <a class="mics-btn mics-btn-action" ng-click="editCampaign(campaign)">Edit Campaign</a>
         </div>
         <span>{{campaign.name}}</span>
-        <div mics-campaign-status="campaign"></div>
+        <div mics-campaign-status="campaign"></div>&nbsp;
         <button type="button" class="mics-btn mics-btn-action btn-xs" ng-click="refresh()">
           <span class="glyphicon glyphicon-refresh"></span>
           Refresh


### PR DESCRIPTION
We don't need to wait for the stats to fetch the campaign and display
the campaign name: the media performance stats takes a long time,
no need to show a broken page in the meantime.

See individual commits for more informations.