### PR TITLE
Stylesheets: fix upload and group id.

### DIFF
--- a/app/src/core/adlayouts/EditOneController.js
+++ b/app/src/core/adlayouts/EditOneController.js
@@ -88,7 +88,7 @@ define(['./module', 'jquery'], function (module, $) {
           }
           Restangular.all('ad_layouts/' + $scope.adLayout.id + '/versions/' + $scope.adLayoutVersion.id)
             .customPUT($scope.adLayoutVersionUpdate, undefined, {organisation_id: organisationId}).then(function (adLayoutVersion) {
-              $scope.pluploadOptions.url = configuration.WS_URL + "/ad_layouts/" + $scope.adLayout.id + "/versions/" + adLayoutVersion.id + "/ad_templates?organisation_id=" + organisationId;
+              $scope.pluploadOptions.url = location.protocol + configuration.WS_URL + "/ad_layouts/" + $scope.adLayout.id + "/versions/" + adLayoutVersion.id + "/ad_templates?organisation_id=" + organisationId;
               optionalUpload();
           });
         } else {
@@ -105,7 +105,7 @@ define(['./module', 'jquery'], function (module, $) {
               $scope.adLayoutVersion.version_id = 1;
             }
             Restangular.all('ad_layouts/' + $scope.adLayoutVersion.ad_layout_id + '/versions').post($scope.adLayoutVersion).then(function (adLayoutVersion) {
-              $scope.pluploadOptions.url = configuration.WS_URL + "/ad_layouts/" + $scope.adLayout.id + "/versions/" + adLayoutVersion.id + "/ad_templates?organisation_id=" + organisationId;
+              $scope.pluploadOptions.url = location.protocol + configuration.WS_URL + "/ad_layouts/" + $scope.adLayout.id + "/versions/" + adLayoutVersion.id + "/ad_templates?organisation_id=" + organisationId;
               optionalUpload();
             });
           });

--- a/app/src/core/stylesheets/EditOneController.js
+++ b/app/src/core/stylesheets/EditOneController.js
@@ -12,7 +12,7 @@ define(['./module', 'jquery'], function (module, $) {
       $scope.selectedFiles = [];
       $scope.properties = [];
       $scope.styleSheetVersion = {};
-      var pluginGroupId = "com.mediarithmics.datafile.style_sheet";
+      var pluginGroupId = "com.mediarithmics.creative.style_sheet";
       var pluginArtifactId = "style-sheet";
 
       function setUpStyleSheet(styleSheetId, callback) {


### PR DESCRIPTION
Plupload doesn't like protocol relative urls, this commit fix an strange
issue with layout uploads: it works on a local server and fails (the
call to api.mediarithmics.com is silently replaced with the current
domain, navigator.mediarithmics.com) on a production server.
Thanks past me for find this issue on other plupload uses and
documenting it !
Also fix the group id: it was created with a different one.