### PR TITLE
Bid optimizer without report: hide the button.

### DIFF
--- a/app/src/core/bidOptimizer/view.all.html
+++ b/app/src/core/bidOptimizer/view.all.html
@@ -29,7 +29,7 @@
         <td>{{engineProperties['name'].value}}</td>
         <td>{{engineProperties['provider'].value}}</td>
         <td class="actions">
-          <a class="mics-btn mics-btn-action" href="#/{{organisationId}}/library/bidOptimizers/{{bidOptimizer.id}}/models/{{bidOptimizersUsedModel[bidOptimizer.id]}}/report">Details</a>
+          <a class="mics-btn mics-btn-action" href="#/{{organisationId}}/library/bidOptimizers/{{bidOptimizer.id}}/models/{{bidOptimizersUsedModel[bidOptimizer.id]}}/report" ng-show="bidOptimizersUsedModel[bidOptimizer.id]">Details</a>
           <a class="mics-btn mics-btn-action" href="#/{{organisationId}}/library/bidOptimizers/{{bidOptimizer.id}}">Edit</a>
         </td>
       </tr>


### PR DESCRIPTION
Not all bid optimizers have a report and not all report are available.
This commit hides the 'details' button when we don't have anything to
display but a broken page.