### PR TITLE
Fix plugins lists.

### DIFF
--- a/app/src/core/attributionmodels/CreateController.js
+++ b/app/src/core/attributionmodels/CreateController.js
@@ -20,8 +20,7 @@ define(['./module'], function (module) {
       };
 
       $scope.availableAttributionModelProcessors = Restangular.all("plugins").getList({
-        plugin_type : "ATTRIBUTION_PROCESSOR",
-        organisation_id : Session.getCurrentWorkspace().organisation_id
+        plugin_type : "ATTRIBUTION_PROCESSOR"
       }).$object;
 
 

--- a/app/src/core/bidOptimizer/CreateController.js
+++ b/app/src/core/bidOptimizer/CreateController.js
@@ -20,8 +20,7 @@ define(['./module'], function (module) {
       };
 
       $scope.availableBidOptimizerEngines = Restangular.all("plugins").getList({
-        plugin_type : "BID_OPTIMIZATION_ENGINE",
-        organisation_id : Session.getCurrentWorkspace().organisation_id
+        plugin_type : "BID_OPTIMIZATION_ENGINE"
       }).$object;
 
 


### PR DESCRIPTION
The backend code was recently fixed and now filters on the organisation
id if provided. Most of the plugins belong to Mediarithmics, filtering
on the client's organisation id is likely to return no plugin.