### PR TITLE
Default configuration: use api.mediarithmics.local

### DIFF
--- a/app/conf/app-configuration.js.template
+++ b/app/conf/app-configuration.js.template
@@ -2,8 +2,8 @@
   'use strict';
 
   angular.module('core/configuration', []).constant("core/configuration", {
-    "WS_URL" : "http://127.0.0.1:9004/public/v1",
-    "ADS_UPLOAD_URL" : "http://127.0.0.1:9004/public/v1/asset_files",
+    "WS_URL" : "//api.mediarithmics.local/v1",
+    "ADS_UPLOAD_URL" : "http://api.mediarithmics.local/v1/asset_files",
     "ADS_PREVIEW_URL" : "//ads.mediarithmics.local/ads/render",
     "ASSETS_URL" : "http://assets.mediarithmics.local"
   });


### PR DESCRIPTION
It will be more like ADS_PREVIEW_URL and ASSETS_URL and new developers
(or developers reinstalling their machine) will get a working
configuration.