### PR TITLE
Fix nvd3 update 1.8.1 -> 1.8.2.

### DIFF
--- a/app/src/nvd3-templates/doubleLineChart.js
+++ b/app/src/nvd3-templates/doubleLineChart.js
@@ -456,7 +456,6 @@ define(['d3', 'nv.d3'], function (d3, ignore) {
           }
 
           interactiveLayer.tooltip
-            .position({left: pointXLocation + margin.left, top: e.mouseY + margin.top})
             .chartContainer(that.parentNode)
             .enabled(tooltips)
             .valueFormatter(function (d, i) {

--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "videojs-contrib-ads": "^2.0.0",
     "videojs-vast": "^0.2.1",
     "d3": "~3.5.5",
-    "nvd3": "~1.8.1",
+    "nvd3": "~1.8.2",
     "js-xlsx": "~0.8.0",
     "file-saver.js": "~1.20150507.2",
     "moment-duration-format": "~1.3.0",


### PR DESCRIPTION
The `~` version in bower updated the 1.8.1 version of nvd3 to 1.8.2
which changed "Lots of community bugfixes and a few extra
minor features" (yay semver...).

The tooltip positionning changed and started throwing
`TypeError: position is not a function`. The new version works without
tooltip.position so we don't need it anymore.