### PR TITLE
Send js errors to our backend.

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -31,6 +31,7 @@ require.config({
         "async": "../bower_components/async/lib/async",
         "moxie": "../bower_components/plupload/js/moxie",
         "plupload": "../bower_components/plupload/js/plupload.dev",
+        "tracekit": "../bower_components/tracekit/tracekit",
 
 
         // Angular JS modules
@@ -78,6 +79,7 @@ require.config({
         'ui.router.extras': ['angular', 'ui.router'],
         'ngload': ['angularAMD'],
         'js-xlsx': ['angular', 'file-saver'],
+        'tracekit': {exports: 'TraceKit'},
         // Navigator configuration
         'core/configuration': ['angular'],
         'lvlUuid': ['angular'],

--- a/app/src/app-setup.js
+++ b/app/src/app-setup.js
@@ -23,6 +23,7 @@ define([
   'angular-nvd3',
   'bootstrap-tokenfield',
   'core/configuration',
+  'core/common/index',
   'core/adblock/index',
   'core/adlayouts/index',
   'core/assets/index',

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -2,11 +2,13 @@ define(['app-setup', 'angularAMD'],
   function (app, angularAMD) {
     'use strict';
 
-    app.run(['$rootScope', '$location', '$log', 'core/common/auth/AuthenticationService', 'core/common/auth/Session', "lodash", "core/login/constants",
-      function ($rootScope, $location, $log, AuthenticationService, Session, _, LoginConstants) {
+    app.run(['$rootScope', '$location', '$log', 'core/common/auth/AuthenticationService', 'core/common/auth/Session', "lodash", "core/login/constants", "core/common/ErrorReporting",
+      function ($rootScope, $location, $log, AuthenticationService, Session, _, LoginConstants, ErrorReporting) {
         var defaults = _.partialRight(_.assign, function (a, b) {
           return typeof a === 'undefined' ? b : a;
         });
+
+        ErrorReporting.setup();
 
         function updateWorkspaces() {
           $rootScope.currentOrganisation = Session.getCurrentWorkspace().organisation_name;

--- a/app/src/core/common/ErrorReporting.js
+++ b/app/src/core/common/ErrorReporting.js
@@ -1,0 +1,47 @@
+define(['./module'], function (module) {
+  "use strict";
+
+  /**
+   * This is a really simple error reporting module, nothing fancy.
+   * It will send js errors to our backend.
+   * I know there are a lost of paying solutions to track these and
+   * display nice reports, etc but for now I just want to know WHY
+   * a user has an issue. The fancy reports can come latter.
+   */
+  module.factory('core/common/ErrorReporting', [
+    "tracekit", "jquery", "core/common/auth/Session",
+    function (TraceKit, $, Session) {
+      return {
+        /**
+         * Setup the report module: configure stuff, add the reporter.
+         */
+        setup: function setup() {
+          TraceKit.remoteFetching = false;
+          TraceKit.report.subscribe(function(errorReport) {
+
+            errorReport.current_page = location.toString();
+            errorReport.user_agent = navigator.userAgent;
+            if(Session.getCurrentWorkspace()) {
+              errorReport.current_organisation_id = Session.getCurrentWorkspace().organisation_id;
+            }
+            if(Session.getUserProfile()) {
+              errorReport.user_id = Session.getUserProfile().id;
+            }
+            errorReport.current_datamart_id = Session.getCurrentDatamartId();
+
+            // console.error("TRACEKIT REPORT", JSON.stringify(errorReport));
+            $.ajax("/log_errors.html", {data: errorReport});
+          });
+        },
+        /**
+         * Report a new error.
+         * @param {Error} e the error to report.
+         */
+        report: function report(e) {
+          TraceKit.report(e);
+        }
+      };
+    }
+  ]);
+
+});

--- a/app/src/navigator.js
+++ b/app/src/navigator.js
@@ -1,5 +1,5 @@
-define(['navigator-setup', 'angularAMD', 'lodash', 'async', 'jquery', 'plupload', 'd3', 'moment', 'clipboard'],
-  function (navigator, angularAMD, lodash, async, jquery, plupload, d3, moment, Clipboard) {
+define(['navigator-setup', 'angularAMD', 'lodash', 'async', 'jquery', 'plupload', 'd3', 'moment', 'clipboard', 'tracekit'],
+  function (navigator, angularAMD, lodash, async, jquery, plupload, d3, moment, Clipboard, TraceKit) {
     "use strict";
 
     navigator.factory('lodash', [
@@ -35,6 +35,12 @@ define(['navigator-setup', 'angularAMD', 'lodash', 'async', 'jquery', 'plupload'
     navigator.factory('moment', [
       function () {
         return moment;
+      }
+    ]);
+
+    navigator.factory('tracekit', [
+      function () {
+        return TraceKit;
       }
     ]);
 

--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,8 @@
     "bootstrap-tokenfield": "0.12.1",
     "lvlDragDrop": "*",
     "clipboard": "~1.5.5",
-    "angular-nvd3": "~1.0.5"
+    "angular-nvd3": "~1.0.5",
+    "tracekit": "^0.3.1"
   },
   "devDependencies": {
     "angular-mocks": "1.3.15",


### PR DESCRIPTION
This is a really simple error reporting module, nothing fancy.
It will send js errors to our backend.

I know there are a lost of paying solutions to track these and
display nice reports, etc but for now I just want to know WHY
a user has an issue. The fancy reports can come latter.