### PR TITLE
Allow query on families with $

### DIFF
--- a/app/src/core/datamart/queries/QueryDirectives.js
+++ b/app/src/core/datamart/queries/QueryDirectives.js
@@ -258,6 +258,9 @@ define(['./module'], function (module) {
                             return value;
                         }
                     };
+                    $scope.cleanupId = function (value) {
+                      return value.replace( /(:|\.|\[|\]|,|\$)/g, "\\$1");
+                    }
 
                     $scope.indexOptions = Common.indexOptions;
 

--- a/app/src/core/datamart/queries/QueryDirectives.js
+++ b/app/src/core/datamart/queries/QueryDirectives.js
@@ -260,7 +260,7 @@ define(['./module'], function (module) {
                     };
                     $scope.cleanupId = function (value) {
                       return value.replace( /(:|\.|\[|\]|,|\$)/g, "\\$1");
-                    }
+                    };
 
                     $scope.indexOptions = Common.indexOptions;
 

--- a/app/src/core/datamart/queries/QueryService.js
+++ b/app/src/core/datamart/queries/QueryService.js
@@ -8,7 +8,7 @@ define(['./module'], function (module) {
       var service = {};
 
       service.getPropertySelectorDisplayName = function(selectorName, selectorParameter, selectorExpression, selectorLabel) {
-        var name = selectorName;        
+        var name = selectorName;
         if (selectorParameter){
           if (selectorParameter.startsWith("[")){
             name = JSON.parse(selectorParameter).join(".");
@@ -27,7 +27,7 @@ define(['./module'], function (module) {
 
       service.getSelectorFamilyName = function(selectorFamily, familyParameter){
         if (selectorFamily === 'USER_EVENTS'){
-          return familyParameter;
+          return service.getSelectorFamilyName(familyParameter);
         } else if (Common.familyLabels[selectorFamily]) {
           return Common.familyLabels[selectorFamily];
         } else {
@@ -55,6 +55,8 @@ define(['./module'], function (module) {
         var elementLabel = "";
         if (Common.elementLabels[family]){
           elementLabel = Common.elementLabels[family];
+        } else if (Common.elementLabels[familyParameter]){
+          elementLabel = Common.elementLabels[familyParameter];
         } else {
           elementLabel = familyParameter;
         }

--- a/app/src/core/datamart/queries/common/Common.js
+++ b/app/src/core/datamart/queries/common/Common.js
@@ -73,11 +73,15 @@ define(['./module'], function (module) {
       var familyLabels = { USER_PROFILE:"Profile", USER_VISITS:"Visits" ,
                            USER_CONVERSIONS:"Conversions", USER_DEVICES:"Devices",
                            USER_SEGMENTS:"Segments", USER_EMAILS:"Emails",
-                           USER_TOUCHES:"Touches", USER_EMAIL_ADDRESSES:"Email Addresses"};
+                           USER_TOUCHES:"Touches", USER_EMAIL_ADDRESSES:"Email Addresses",
+                           "$product_view":"Product views",
+                           "$product_list_view":"Product list views"};
       var elementLabels = { USER_PROFILE:"Profile", USER_VISITS:"Visit" ,
                             USER_CONVERSIONS:"Conversion", USER_DEVICES:"Device",
                             USER_SEGMENTS:"Segment", USER_EMAILS:"Email",
-                            USER_TOUCHES:"Touch", USER_EMAIL_ADDRESSES:"Email Address"};
+                            USER_TOUCHES:"Touch", USER_EMAIL_ADDRESSES:"Email Address",
+                            "$product_view":"Product view",
+                            "$product_list_view":"Product list view"};
 
       var propertySelectorExpressions = [
         {name:"MAX", applicableSelectorType:["INTEGER","DOUBLE","LONG"], applicableEvaluationType:["ARRAY","TABLE"]},

--- a/app/src/core/datamart/queries/query-ui.html
+++ b/app/src/core/datamart/queries/query-ui.html
@@ -13,12 +13,12 @@
           <div class="panel-heading">
             <h4 class="panel-title">
               <a data-toggle="collapse" data-parent="#accordion"
-                 data-target="#criteria_{{family.id}}">
+                 data-target="#criteria_{{cleanupId(family.id)}}">
                 {{family.name}}
               </a>
             </h4>
           </div>
-          <div id="criteria_{{family.id}}" class="panel-collapse collapse">
+          <div id="criteria_{{cleanupId(family.id)}}" class="panel-collapse collapse">
             <div class="panel-body selector-panel">
               <div ng-repeat="selector in family.selectors">
                 <div ng-if="selector.value.selector_name !== 'INDEX'" x-lvl-draggable='true' data-family="{{family.name}}">


### PR DESCRIPTION
When using a data-label in uib, the $ needs to be escaped, like other
css characters.
see https://learn.jquery.com/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation/