### PR TITLE
Ad layout: rename format to optimal_formats.

### DIFF
--- a/app/src/core/adlayouts/CreateOneController.js
+++ b/app/src/core/adlayouts/CreateOneController.js
@@ -21,7 +21,7 @@ define(['./module', 'jquery'], function (module, $) {
         }
         $scope.adRendererVersions = [renderers[0].current_version_id];
         $.extend($scope.adLayout, {
-          format: "300x250",
+          optimal_formats: "",
           renderer_id: renderers[0].id,
           renderer_version_id: renderers[0].current_version_id
         });
@@ -40,7 +40,6 @@ define(['./module', 'jquery'], function (module, $) {
       });
 
       $scope.saveAndCreateNewVersion = function () {
-        $scope.adLayout.format = "F" + $scope.adLayout.format;
         Restangular.all('ad_layouts').post($scope.adLayout).then(function (adLayout) {
           $location.path("/" + organisationId + "/library/adlayouts/" + adLayout.id + "/new-version");
         }, function (err) {
@@ -49,7 +48,6 @@ define(['./module', 'jquery'], function (module, $) {
       };
 
       $scope.done = function () {
-        $scope.adLayout.format = "F" + $scope.adLayout.format;
         return Restangular.all('ad_layouts').post($scope.adLayout).then(function () {
           $location.path('/' + organisationId + "/library/adlayouts");
         }, function (err) {

--- a/app/src/core/adlayouts/EditOneController.js
+++ b/app/src/core/adlayouts/EditOneController.js
@@ -27,14 +27,7 @@ define(['./module', 'jquery'], function (module, $) {
       function setUpAdLayout(adLayoutId, callback) {
         Restangular.one("ad_layouts", adLayoutId).get({organisation_id: organisationId})
           .then(function (adLayout) {
-            $scope.adLayout = {
-              id: adLayoutId,
-              name: adLayout.name,
-              organisation_id: organisationId,
-              format: adLayout.format.substring(1),
-              renderer_id: adLayout.renderer_id,
-              renderer_version_id: adLayout.renderer_version_id
-            };
+            $scope.adLayout = adLayout;
             $scope.adRendererVersions = [$scope.adLayout.renderer_version_id];
           })
           .then(callback);

--- a/app/src/core/adlayouts/ViewAllController.js
+++ b/app/src/core/adlayouts/ViewAllController.js
@@ -51,14 +51,7 @@ define(['./module', 'jquery'], function (module, $) {
         Restangular.all("ad_layouts").getList({organisation_id: organisationId}).then(function (adLayouts) {
           for (var i = 0; i < adLayouts.length; ++i) {
             var adLayout = adLayouts[i];
-            $scope.adLayouts.push({
-              id: adLayout.id,
-              name: adLayout.name,
-              format: adLayout.format,
-              renderer_id: adLayout.renderer_id,
-              renderer_version_id: adLayout.renderer_version_id,
-              organisation_id: adLayout.organisation_id
-            });
+            $scope.adLayouts.push(adLayout);
             addAdLayoutRendererVersion(adLayout.id, adLayout.renderer_id, adLayout.renderer_version_id);
             Restangular.one("ad_layouts", adLayout.id).one("versions").get({
               organisation_id: organisationId,

--- a/app/src/core/adlayouts/create.one.html
+++ b/app/src/core/adlayouts/create.one.html
@@ -20,8 +20,8 @@
     <div class="row">
       <!-- Format -->
       <div class="col-md-2">
-        <div mcs-form-group="full" label-for="format" label-text="Compatible Format">
-          <select ng-model="adLayout.format" ng-options="adSize for adSize in adSizes" id="format"></select>
+        <div mcs-form-group="full" label-for="optimal_formats" label-text="Compatible Formats">
+          <input required class="input-lg" ng-model="adLayout.optimal_formats" type="text" id="optimal_formats">
         </div>
       </div>
     </div>

--- a/app/src/core/adlayouts/view.all.html
+++ b/app/src/core/adlayouts/view.all.html
@@ -20,7 +20,7 @@
       <thead>
       <tr>
         <th>Name</th>
-        <th>Format</th>
+        <th>Optimal Formats</th>
         <th>Renderer</th>
         <th>Renderer Version</th>
         <th class="actions">Actions</th>
@@ -29,7 +29,7 @@
       <tbody data-ng-repeat="adLayout in filteredAdLayouts() | offset: (currentPage - 1) * itemsPerPage | limitTo: itemsPerPage">
       <tr data-target="#demo{{$index}}" data-toggle="collapse" class="accordion-toggle clickableRow" title="Click to collapse/expand this ad layout versions">
         <td>{{adLayout.name}}</td>
-        <td>{{adLayout.format}}</td>
+        <td>{{adLayout.optimal_formats}}</td>
         <td>{{adRenderers[adLayout.renderer_id]}}</td>
         <td>{{adLayoutRendererVersions[adLayout.id]}}</td>
         <td class="actions">


### PR DESCRIPTION
This follows the API change where the previous `format`, an enum that
represents the format of the ad layout, has been replaced by
`optimal_formats`, a free field that can be used to indicate when to use
the layout (vertical, horizontal, mostly square, etc).