### PR TITLE
External Campaign

### DIFF
--- a/app/src/core/adgroups/AddAdController.js
+++ b/app/src/core/adgroups/AddAdController.js
@@ -1,0 +1,27 @@
+define(['./module'], function (module) {
+  'use strict';
+
+  module.controller('core/adgroups/AddAdController', [
+    '$scope', '$uibModalInstance', 'lodash', 'core/common/IabService',
+    function ($scope, $uibModalInstance, _, IabService) {
+      $scope.ad = {};
+
+      $scope.iabAdSizes = _.map(IabService.getAdSizes("BANNER"), function (size) {
+        return size.format;
+      });
+
+      $scope.done = function () {
+        $scope.$broadcast("display-ad/basic-editor:save");
+      };
+
+      $scope.canSave = function() {
+        return $scope.ad.technical_name && $scope.ad.name && $scope.ad.format;
+      };
+
+      $scope.cancel = function () {
+        $uibModalInstance.close();
+      };
+    }
+  ]);
+});
+

--- a/app/src/core/adgroups/AddAdController.js
+++ b/app/src/core/adgroups/AddAdController.js
@@ -11,7 +11,7 @@ define(['./module'], function (module) {
       });
 
       $scope.done = function () {
-        $scope.$broadcast("display-ad/basic-editor:save");
+        $uibModalInstance.close($scope.ad);
       };
 
       $scope.canSave = function() {

--- a/app/src/core/adgroups/ChooseExistingAdsController.js
+++ b/app/src/core/adgroups/ChooseExistingAdsController.js
@@ -31,7 +31,7 @@ define(['./module'], function (module) {
             creative: creative
           });
         }
-        $uibModalInstance.close();
+        $uibModalInstance.close(creative);
       };
 
       $scope.cancel = function () {

--- a/app/src/core/adgroups/ChooseExternalAdsController.js
+++ b/app/src/core/adgroups/ChooseExternalAdsController.js
@@ -2,8 +2,8 @@ define(['./module'], function (module) {
   'use strict';
 
   module.controller("core/adgroups/ChooseExternalAdsController", [
-    "$scope", "$uibModal", "$log", "$q", "core/common/ads/AdService", "core/creatives/plugins/display-ad/DisplayAdService",
-    function ($scope, $uibModal, $log, $q, AdService, DisplayAdService) {
+    "$scope", "$uibModal", "$log", "$q", "core/common/ads/AdService",
+    function ($scope, $uibModal, $log, $q, AdService) {
       $scope.ads = [];
 
       $scope.setAdTypeToDisplayAd = function () {
@@ -14,9 +14,8 @@ define(['./module'], function (module) {
         AdService.setAdTypeToVideoAd();
       };
 
-      // Upload new Ad
+      // We call add ad but we actually get an object with info for both a creative and an ad.
       $scope.addAd = function () {
-        // Display pop-up
         var uploadModal = $uibModal.open({
           templateUrl: 'src/core/adgroups/add-ad.html',
           scope: $scope,
@@ -24,9 +23,9 @@ define(['./module'], function (module) {
           controller: 'core/adgroups/AddAdController'
         });
 
-        uploadModal.result.then(function (ad) {
-          if (ad) {
-            $scope.$emit("mics-creative:add-ad", {ad: ad});
+        uploadModal.result.then(function (creative) {
+          if (creative) {
+            $scope.$emit("mics-creative:add-creative", {creative: creative});
           }
         });
       };

--- a/app/src/core/adgroups/ChooseExternalAdsController.js
+++ b/app/src/core/adgroups/ChooseExternalAdsController.js
@@ -2,8 +2,9 @@ define(['./module'], function (module) {
   'use strict';
 
   module.controller("core/adgroups/ChooseExternalAdsController", [
-    "$scope", "$uibModal", "$log", "$q", "core/common/ads/AdService",
-    function ($scope, $uibModal, $log, $q, AdService) {
+    "$scope", "$uibModal", "$log", "$q", "core/common/ads/AdService", "core/creatives/plugins/display-ad/DisplayAdService",
+    function ($scope, $uibModal, $log, $q, AdService, DisplayAdService) {
+      $scope.ads = [];
 
       $scope.setAdTypeToDisplayAd = function () {
         AdService.setAdTypeToDisplayAd();
@@ -23,7 +24,11 @@ define(['./module'], function (module) {
           controller: 'core/adgroups/AddAdController'
         });
 
-        uploadModal.result.then(function () {});
+        uploadModal.result.then(function (ad) {
+          if (ad) {
+            $scope.$emit("mics-creative:add-ad", {ad: ad});
+          }
+        });
       };
 
       // Select existing Ads

--- a/app/src/core/adgroups/ChooseExternalAdsController.js
+++ b/app/src/core/adgroups/ChooseExternalAdsController.js
@@ -41,7 +41,11 @@ define(['./module'], function (module) {
           size: 'lg'
         });
 
-        uploadModal.result.then(function () {});
+        uploadModal.result.then(function (creative) {
+          if (creative) {
+            $scope.$emit("mics-creative:add-creative", {creative: creative});
+          }
+        });
       };
     }
   ]);

--- a/app/src/core/adgroups/ChooseExternalAdsController.js
+++ b/app/src/core/adgroups/ChooseExternalAdsController.js
@@ -1,0 +1,44 @@
+define(['./module'], function (module) {
+  'use strict';
+
+  module.controller("core/adgroups/ChooseExternalAdsController", [
+    "$scope", "$uibModal", "$log", "$q", "core/common/ads/AdService",
+    function ($scope, $uibModal, $log, $q, AdService) {
+
+      $scope.setAdTypeToDisplayAd = function () {
+        AdService.setAdTypeToDisplayAd();
+      };
+
+      $scope.setAdTypeToVideoAd = function () {
+        AdService.setAdTypeToVideoAd();
+      };
+
+      // Upload new Ad
+      $scope.addAd = function () {
+        // Display pop-up
+        var uploadModal = $uibModal.open({
+          templateUrl: 'src/core/adgroups/add-ad.html',
+          scope: $scope,
+          backdrop: 'static',
+          controller: 'core/adgroups/AddAdController'
+        });
+
+        uploadModal.result.then(function () {});
+      };
+
+      // Select existing Ads
+      $scope.selectExistingAd = function () {
+        // Display pop-up
+        var uploadModal = $uibModal.open({
+          templateUrl: 'src/core/adgroups/ChooseExistingAds.html',
+          scope: $scope,
+          backdrop: 'static',
+          controller: 'core/adgroups/ChooseExistingAdsController',
+          size: 'lg'
+        });
+
+        uploadModal.result.then(function () {});
+      };
+    }
+  ]);
+});

--- a/app/src/core/adgroups/add-ad.html
+++ b/app/src/core/adgroups/add-ad.html
@@ -1,0 +1,33 @@
+<form ng-submit="done()">
+  <div class="modal-header">
+    <h3>Add Ad</h3>
+  </div>
+
+  <div class="modal-body">
+    <div class="row">
+      <!-- Name -->
+      <div class="form-group col-md-9">
+        <div mcs-form-group="" label-for="name" label-text="Ad name">
+          <input ng-model="ad.name" type="text" class="form-control input-md" id="name">
+        </div>
+      </div>
+
+      <!-- Format -->
+      <div class="form-group col-md-3">
+        <div mcs-form-group="full" label-for="format" label-text="Format">
+          <select class="form-control" ng-model="ad.format" ng-options="iabAdSize for iabAdSize in iabAdSizes" id="format"></select>
+        </div>
+      </div>
+    </div>
+
+    <!-- Technical Name -->
+    <div mcs-form-group="" label-for="technical-name" label-text="Technical name">
+      <input ng-model="ad.technical_name" type="text" class="form-control input-md" id="technical-name">
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <button class="mics-btn mics-btn-finish" ng-disabled="!canSave()">Done</button>
+    <a ng-click="cancel()" class="mics-btn mics-btn-cancel">Cancel</a>
+  </div>
+</form>

--- a/app/src/core/adgroups/choose-external-ads.html
+++ b/app/src/core/adgroups/choose-external-ads.html
@@ -1,0 +1,36 @@
+<div ng-controller="core/adgroups/ChooseExternalAdsController">
+  <form>
+    <div class="form-group">
+      <div class="row">
+        <div class="col-lg-6">
+          <div uib-dropdown>
+            <button ng-click="setAdTypeToDisplayAd()" class="mics-btn mics-btn-add" uib-dropdown-toggle type="button">
+              Add Display Ads
+            </button>
+            <ul class="dropdown-menu" role="menu" aria-labelledby="add ads">
+              <li role="presentation"><a role="menuitem" tabindex="-1" ng-click="selectExistingAd()">
+                Choose From Library
+              </a></li>
+              <li role="presentation"><a role="menuitem" tabindex="-1" ng-click="addAd()">
+                Add Ad
+              </a></li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="col-lg-6">
+          <div class="dropdown" uib-dropdown>
+            <button ng-click="setAdTypeToVideoAd()" class="mics-btn mics-btn-add" uib-dropdown-toggle type="button">
+              Add Video Ads
+            </button>
+            <ul class="dropdown-menu" role="menu" aria-labelledby="add ads">
+              <li role="presentation"><a role="menuitem" tabindex="-1" ng-click="selectExistingAd()">
+                Choose From Library
+              </a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>

--- a/app/src/core/campaigns/CampaignPluginService.js
+++ b/app/src/core/campaigns/CampaignPluginService.js
@@ -40,7 +40,7 @@ define(['./module'], function (module) {
           name: "Desktop & Mobile",
           editor_version_id: "11",
           group_id: "com.mediarithmics.campaign.display",
-          artifact_id: "default-template",
+          artifact_id: "default-editor",
           image: "/images/plugins/multi-targeting-small.png",
           editor: {
             create_path: "/{organisation_id}/campaigns/display/expert/edit/{id}",
@@ -51,22 +51,22 @@ define(['./module'], function (module) {
           name: "Simplified Keywords Targeting",
           editor_version_id: "12",
           group_id: "com.mediarithmics.campaign.display",
-          artifact_id: "keywords-targeting-template",
+          artifact_id: "keywords-targeting-editor",
           image: "/images/plugins/keywords-targeting-small.png",
           editor: {
             create_path: "/{organisation_id}/campaigns/display/keywords",
             edit_path: "/{organisation_id}/campaigns/display/keywords/{id}"
-          },
+          }
         }),
         new CampaignTemplate({
-          name: "Email campaign Default Editor",
-          editor_version_id: "17",
-          group_id: "com.mediarithmics.campaign.email",
-          artifact_id: "default-editor",
-          image: "/images/plugins/email-campaign-expert-small.png",
+          name: "External Campaign",
+          editor_version_id: "1027",
+          group_id: "com.mediarithmics.campaign.display",
+          artifact_id: "external-campaign-editor",
+          image: "/images/plugins/multi-targeting-small.png",
           editor: {
-            create_path: "/{organisation_id}/campaigns/email/edit",
-            edit_path: "/{organisation_id}/campaigns/email/edit/{id}"
+            create_path: "/{organisation_id}/campaigns/display/external/edit/{id}",
+            edit_path: "/{organisation_id}/campaigns/display/external/{id}"
           }
         })
       ];

--- a/app/src/core/campaigns/CampaignPluginService.js
+++ b/app/src/core/campaigns/CampaignPluginService.js
@@ -66,7 +66,7 @@ define(['./module'], function (module) {
           image: "/images/plugins/multi-targeting-small.png",
           editor: {
             create_path: "/{organisation_id}/campaigns/display/external/edit/{id}",
-            edit_path: "/{organisation_id}/campaigns/display/external/{id}"
+            edit_path: "/{organisation_id}/campaigns/display/external/edit/{id}"
           }
         })
       ];

--- a/app/src/core/campaigns/DisplayCampaignService.js
+++ b/app/src/core/campaigns/DisplayCampaignService.js
@@ -31,7 +31,7 @@ define(['./module'], function (module) {
       };
 
       service.initCreateCampaign = function (template) {
-        var campaignCtn = new DisplayCampaignContainer(template.editor_version_id,Session.getCurrentWorkspace() );
+        var campaignCtn = new DisplayCampaignContainer(template.editor_version_id, Session.getCurrentWorkspace());
         campaignCtn.id = IdGenerator.getId();
         campaignCtn.organisationId = Session.getCurrentWorkspace().organisation_id;
 
@@ -44,7 +44,7 @@ define(['./module'], function (module) {
       };
 
       service.initEditCampaign = function (campaignId, template) {
-        var campaignCtn = new DisplayCampaignContainer(template.editor_version_id, Session.getCurrentWorkspace() );
+        var campaignCtn = new DisplayCampaignContainer(template.editor_version_id, Session.getCurrentWorkspace());
         this.campaignCtn = campaignCtn;
         return campaignCtn.load(campaignId);
       };

--- a/app/src/core/campaigns/expert/EditCampaignController.js
+++ b/app/src/core/campaigns/expert/EditCampaignController.js
@@ -52,7 +52,7 @@ define(['./module', 'moment'], function (module, moment) {
         }
       }
 
-      CampaignPluginService.getCampaignEditor("com.mediarithmics.campaign.display", "default-template").then(function (template) {
+      CampaignPluginService.getCampaignEditor("com.mediarithmics.campaign.display", "default-editor").then(function (template) {
         // TODO load the campaign (no effect if already in cache or if this is a temporary id)
         if (!DisplayCampaignService.isInitialized() || DisplayCampaignService.getCampaignId() !== campaignId) {
           if (!campaignId || DisplayCampaignService.isTemporaryId(campaignId)) {

--- a/app/src/core/campaigns/external/EditAdGroupController.js
+++ b/app/src/core/campaigns/external/EditAdGroupController.js
@@ -1,0 +1,51 @@
+define(['./module'], function (module) {
+  'use strict';
+
+  /**
+   * Display Campaign Template Module
+   * Template : external-campaign-editor
+   */
+
+  module.controller('core/campaigns/external/EditAdGroupController', [
+    '$scope', '$location', '$stateParams', '$log', 'core/campaigns/DisplayCampaignService', 'lodash','core/common/auth/Session',
+    function($scope, $location, $stateParams, $log, DisplayCampaignService, _, Session) {
+      var adGroupId = $stateParams.ad_group_id;
+      var campaignId = $stateParams.campaign_id;
+      if (!DisplayCampaignService.isInitialized() || DisplayCampaignService.getCampaignId() !== campaignId) {
+        return $location.path(Session.getWorkspacePrefixUrl()+ "/campaigns/display/external/edit/" + campaignId);
+      }
+
+      $scope.campaignName = DisplayCampaignService.getCampaignValue().name;
+      $scope.adGroup = DisplayCampaignService.getAdGroupValue(adGroupId);
+
+      $scope.getAds = function (adGroupId) {
+        return DisplayCampaignService.getAds(adGroupId);
+      };
+
+      $scope.deleteAd = function (adId) {
+        return DisplayCampaignService.removeAd(adGroupId, adId);
+      };
+
+      $scope.$on("mics-creative:selected", function (event, params) {
+        var ad = {creative_id: params.creative.id};
+        DisplayCampaignService.addAd(adGroupId, ad);
+      });
+
+      $scope.canSave = function() {
+        return $scope.adGroup.name && $scope.adGroup.technical_name;
+      };
+
+      $scope.done = function () {
+        $log.debug("Editing Ad Group done! :", $scope.adGroup);
+        DisplayCampaignService.setAdGroupValue(adGroupId, $scope.adGroup);
+        $location.path(Session.getWorkspacePrefixUrl()+ '/campaigns/display/external/edit/' + DisplayCampaignService.getCampaignId());
+      };
+
+      $scope.cancel = function () {
+        $log.debug("Reset Ad Group");
+        DisplayCampaignService.resetAdGroup(adGroupId);
+        $location.path(Session.getWorkspacePrefixUrl()+ '/campaigns/display/external/edit/' + DisplayCampaignService.getCampaignId());
+      };
+    }
+  ]);
+});

--- a/app/src/core/campaigns/external/EditAdGroupController.js
+++ b/app/src/core/campaigns/external/EditAdGroupController.js
@@ -1,4 +1,4 @@
-define(['./module'], function (module) {
+define(['./module', 'angular', 'jquery'], function (module, angular, jquery) {
   'use strict';
 
   /**
@@ -7,12 +7,12 @@ define(['./module'], function (module) {
    */
 
   module.controller('core/campaigns/external/EditAdGroupController', [
-    '$scope', '$location', '$stateParams', '$log', 'core/campaigns/DisplayCampaignService', 'lodash','core/common/auth/Session',
-    function($scope, $location, $stateParams, $log, DisplayCampaignService, _, Session) {
+    '$scope', '$location', '$stateParams', '$log', 'core/campaigns/DisplayCampaignService', 'lodash', 'core/common/auth/Session', "core/creatives/plugins/display-ad/DisplayAdService",
+    function ($scope, $location, $stateParams, $log, DisplayCampaignService, _, Session, DisplayAdService) {
       var adGroupId = $stateParams.ad_group_id;
       var campaignId = $stateParams.campaign_id;
       if (!DisplayCampaignService.isInitialized() || DisplayCampaignService.getCampaignId() !== campaignId) {
-        return $location.path(Session.getWorkspacePrefixUrl()+ "/campaigns/display/external/edit/" + campaignId);
+        return $location.path(Session.getWorkspacePrefixUrl() + "/campaigns/display/external/edit/" + campaignId);
       }
 
       $scope.campaignName = DisplayCampaignService.getCampaignValue().name;
@@ -22,29 +22,63 @@ define(['./module'], function (module) {
         return DisplayCampaignService.getAds(adGroupId);
       };
 
-      $scope.deleteAd = function (adId) {
-        return DisplayCampaignService.removeAd(adGroupId, adId);
+      $scope.ads = $scope.getAds($scope.adGroup.id);
+      console.log("Ad group: ", $scope.adGroup);
+      console.log("Ads: ", $scope.ads);
+
+      $scope.deleteAd = function (ad) {
+        if (angular.isDefined(ad.id)) {
+          DisplayCampaignService.removeAd(adGroupId, ad.id);
+        }
+        var index = $scope.ads.indexOf(ad);
+        $scope.ads.splice(index, 1);
       };
 
-      $scope.$on("mics-creative:selected", function (event, params) {
-        var ad = {creative_id: params.creative.id};
-        DisplayCampaignService.addAd(adGroupId, ad);
+
+      $scope.$on("mics-creative:add-ad", function (event, params) {
+        $scope.ads.push(params.ad);
       });
 
-      $scope.canSave = function() {
+      $scope.canSave = function () {
         return $scope.adGroup.name && $scope.adGroup.technical_name;
       };
 
+      function createCreative(name, technicalName, format) {
+        var options = {
+          renderer: {
+            groupId: "com.mediarithmics.creative.display",
+            artifactId: "image-iframe"
+          },
+          editor: {
+            groupId: "com.mediarithmics.creative.display",
+            artifactId: "default-editor"
+          },
+          subtype: "BANNER"
+        };
+        var creativeContainer = DisplayAdService.initCreateDisplayAd(options);
+        creativeContainer.value.name = name;
+        creativeContainer.value.technical_name = technicalName;
+        creativeContainer.value.format = format;
+        return creativeContainer.persist();
+      }
+
       $scope.done = function () {
+        var ads = jquery.extend(true, {}, $scope.ads);
+        for (var i = 0; i < ads.length; ++i) {
+          var ad = ads[i];
+          createCreative(ad.name, ad.technical_name, ad.format);
+          DisplayCampaignService.addAd(adGroupId, ad);
+        }
+
         $log.debug("Editing Ad Group done! :", $scope.adGroup);
         DisplayCampaignService.setAdGroupValue(adGroupId, $scope.adGroup);
-        $location.path(Session.getWorkspacePrefixUrl()+ '/campaigns/display/external/edit/' + DisplayCampaignService.getCampaignId());
+        $location.path(Session.getWorkspacePrefixUrl() + '/campaigns/display/external/edit/' + DisplayCampaignService.getCampaignId());
       };
 
       $scope.cancel = function () {
         $log.debug("Reset Ad Group");
         DisplayCampaignService.resetAdGroup(adGroupId);
-        $location.path(Session.getWorkspacePrefixUrl()+ '/campaigns/display/external/edit/' + DisplayCampaignService.getCampaignId());
+        $location.path(Session.getWorkspacePrefixUrl() + '/campaigns/display/external/edit/' + DisplayCampaignService.getCampaignId());
       };
     }
   ]);

--- a/app/src/core/campaigns/external/EditAdGroupController.js
+++ b/app/src/core/campaigns/external/EditAdGroupController.js
@@ -70,15 +70,31 @@ define(['./module', 'angular', 'jquery'], function (module, angular, $) {
         return creativeContainer.persist();
       }
 
+      function adsContain(creativeId) {
+        for (var i = 0; i < $scope.ads.length; ++i) {
+          if ($scope.ads[i].creative_id === "" + creativeId) {
+            return true;
+          }
+        }
+        return false;
+      }
+
       function createCreatives() {
-        var promises = $scope.creatives.filter(function (val) {
-          return val.id === undefined;
-        }).map(function (creative) {
-          return createCreative(creative.name, creative.technical_name, creative.format).then(function (createdCreative) {
-            var ad = {creative_id: createdCreative.id};
-            ad.creative_id = createdCreative.id;
+        var promises = $scope.creatives.map(function (creative) {
+          if (creative.id === undefined) {
+            return createCreative(creative.name, creative.technical_name, creative.format).then(function (createdCreative) {
+              var ad = {creative_id: createdCreative.id};
+              ad.creative_id = createdCreative.id;
+              DisplayCampaignService.addAd(adGroupId, ad);
+            });
+          } else if (!adsContain(creative.id)) {
+            var ad = {creative_id: creative.id};
+            ad.creative_id = creative.id;
             DisplayCampaignService.addAd(adGroupId, ad);
-          });
+            $q.resolve(ad);
+          } else {
+            $q.resolve();
+          }
         });
 
         return $q.all(promises);

--- a/app/src/core/campaigns/external/EditAdGroupController.js
+++ b/app/src/core/campaigns/external/EditAdGroupController.js
@@ -36,10 +36,16 @@ define(['./module', 'angular', 'jquery'], function (module, angular, $) {
         }
       }
 
-      $scope.deleteAd = function (ad) {
-        if (angular.isDefined(ad.id)) {
-          $scope.creatives.slice($scope.creatives.indexOf(ad.id), 1);
-          DisplayCampaignService.removeAd(adGroupId, ad.id);
+      $scope.deleteAd = function (creative) {
+        if (angular.isDefined(creative.id)) {
+          $scope.creatives = $scope.creatives.filter(function (val) {
+            return val.id !== creative.id;
+          });
+          for (var i = 0; i < $scope.ads.length; ++i) {
+            if ($scope.ads[i].creative_id === creative.id) {
+              DisplayCampaignService.removeAd(adGroupId, $scope.ads[i].id);
+            }
+          }
         }
       };
 

--- a/app/src/core/campaigns/external/EditCampaignController.js
+++ b/app/src/core/campaigns/external/EditCampaignController.js
@@ -1,0 +1,97 @@
+define(['./module', 'moment'], function (module, moment) {
+  'use strict';
+
+  /**
+   * Display Campaign Template Module
+   * Template : external
+   */
+
+  module.controller('core/campaigns/external/EditCampaignController', [
+    '$scope', '$log', '$location', '$stateParams', 'core/campaigns/DisplayCampaignService', 'core/campaigns/CampaignPluginService',
+    'core/common/WaitingService', 'core/common/ErrorService', 'core/common/auth/Session',
+    function ($scope, $log, $location, $stateParams, DisplayCampaignService, CampaignPluginService, WaitingService, ErrorService, Session) {
+      var campaignId = $stateParams.campaign_id;
+
+      function initView() {
+        $scope.campaign = DisplayCampaignService.getCampaignValue();
+        $scope.adGroups = DisplayCampaignService.getAdGroupValues();
+        $scope.locations = DisplayCampaignService.getLocations();
+      }
+
+      CampaignPluginService.getCampaignEditor("com.mediarithmics.campaign.display", "external-campaign-editor").then(function (template) {
+        console.log("template " + template);
+
+        // TODO load the campaign (no effect if already in cache or if this is a temporary id)
+        if (!DisplayCampaignService.isInitialized() || DisplayCampaignService.getCampaignId() !== campaignId) {
+          if (!campaignId || DisplayCampaignService.isTemporaryId(campaignId)) {
+            DisplayCampaignService.initCreateCampaign(template).then(function () {
+              initView();
+            });
+          } else {
+            DisplayCampaignService.initEditCampaign(campaignId, template).then(function () {
+              initView();
+              DisplayCampaignService.loadAdGroups();
+            });
+          }
+        } else {
+          console.log("here2");
+          initView();
+        }
+
+        /**
+         * Ad Group Management
+         */
+
+        $scope.newAdGroup = function () {
+          var adGroupId = DisplayCampaignService.addAdGroup();
+          $location.path(Session.getWorkspacePrefixUrl() + '/campaigns/display/external/edit/' + campaignId + '/edit-ad-group/' + adGroupId);
+        };
+
+        $scope.editAdGroup = function (adGroup) {
+          $location.path(Session.getWorkspacePrefixUrl() + '/campaigns/display/external/edit/' + campaignId + '/edit-ad-group/' + adGroup.id);
+        };
+
+        $scope.removeAdGroup = function (adGroup) {
+          DisplayCampaignService.removeAdGroup(adGroup.id);
+          // TODO find a way to let angular handle that automatically.
+          $scope.adGroups = DisplayCampaignService.getAdGroupValues();
+        };
+
+
+        /**
+         * Confirm or cancel campaign editing
+         */
+
+        $scope.save = function () {
+          $scope.campaign.start_date = null;
+          $scope.campaign.end_date = null;
+          WaitingService.showWaitingModal();
+          DisplayCampaignService.save().then(function (campaignContainer) {
+            WaitingService.hideWaitingModal();
+            DisplayCampaignService.reset();
+            $location.path(Session.getWorkspacePrefixUrl() + '/campaigns/display/report/' + campaignContainer.id + '/basic');
+          }, function failure(response) {
+            WaitingService.hideWaitingModal();
+            ErrorService.showErrorModal({
+              error: response
+            }).then(null, function () {
+              DisplayCampaignService.reset();
+            });
+          });
+        };
+
+        $scope.cancel = function () {
+          DisplayCampaignService.reset();
+          if ($scope.campaign && $scope.campaign.id) {
+            $location.path(Session.getWorkspacePrefixUrl() + '/campaigns/display/report/' + $scope.campaign.id + '/basic');
+          } else {
+            $location.path(Session.getWorkspacePrefixUrl());
+          }
+        };
+      });
+    }
+  ])
+  ;
+})
+;
+

--- a/app/src/core/campaigns/external/EditCampaignController.js
+++ b/app/src/core/campaigns/external/EditCampaignController.js
@@ -1,4 +1,4 @@
-define(['./module', 'moment'], function (module, moment) {
+define(['./module'], function (module) {
   'use strict';
 
   /**
@@ -19,8 +19,6 @@ define(['./module', 'moment'], function (module, moment) {
       }
 
       CampaignPluginService.getCampaignEditor("com.mediarithmics.campaign.display", "external-campaign-editor").then(function (template) {
-        console.log("template " + template);
-
         // TODO load the campaign (no effect if already in cache or if this is a temporary id)
         if (!DisplayCampaignService.isInitialized() || DisplayCampaignService.getCampaignId() !== campaignId) {
           if (!campaignId || DisplayCampaignService.isTemporaryId(campaignId)) {
@@ -34,7 +32,6 @@ define(['./module', 'moment'], function (module, moment) {
             });
           }
         } else {
-          console.log("here2");
           initView();
         }
 

--- a/app/src/core/campaigns/external/edit-ad-group.html
+++ b/app/src/core/campaigns/external/edit-ad-group.html
@@ -1,0 +1,74 @@
+<div class="mcs-default-container" ng-controller="core/campaigns/external/EditAdGroupController">
+
+  <div class="mcs-default-sidebar ">
+    <div class="organisation-name-block">
+      {{currentOrganisation}}
+    </div>
+    <div class="mcs-campaign-type ">
+      <img src="/images/plugins/multi-targeting-small.png"><br/>
+      <h4>Multi Targeting</h4>
+    </div>
+  </div>
+
+  <form role="form" class="mcs-default-edit-content mcs-full-page-form">
+
+    <!-- Ad Group edition form -->
+    <div class="mcs-default-heading">
+      <h3>Editing Ad Group</h3>
+      <h4>for {{campaignName}} Campaign</h4>
+    </div>
+
+    <!------------------------ Basic Info ------------------------>
+    <div mcs-form-group="" label-for="name" label-text="Ad Group Name">
+      <input ng-model="adGroup.name" type="text" class="form-control input-lg" id="name">
+    </div>
+
+    <div mcs-form-group="" label-for="technical-name" label-text="Technical Name">
+      <input ng-model="adGroup.technical_name" type="text" class="form-control input-lg" id="technical-name">
+    </div>
+
+    <!------------------------ Select Ads ------------------------>
+    <div class="mcs-form-group">
+      <div class="mics-block-heading">
+        <div ng-include="'src/core/adgroups/choose-external-ads.html'"></div>
+        <span>Select ads</span>
+      </div>
+      <table class="fragment-list-creatives list-ads" ng-show="getAds(adGroup.id).length">
+        <thead>
+        <tr>
+          <th>Size</th>
+          <th>Ad Name</th>
+          <th>Type</th>
+          <th>Url</th>
+          <th>Created</th>
+          <th class="actions">Action</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr ng-repeat="ad in getAds(adGroup.id)" fetch-creative="ad.creative_id as creative with rendererProperties">
+          <td>
+            <div class="mics-small-thumbnail">
+              <img creative-thumbnail="creative.id"/>
+              <div class="caption">
+                {{creative.format}}
+              </div>
+            </div>
+          </td>
+          <td>{{creative.name}}</td>
+          <td>{{creative.creative_type}}</td>
+          <td pretty-print-url="creativeProperties['destination_url'] | rendererProperty"></td>
+          <td>{{creative.creation_date|date:'shortDate'}}</td>
+          <td class="actions"><button class="mics-btn mics-btn-delete" ng-click="deleteAd(ad.id)">Remove</button></td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Save or cancel -->
+    <div class="mcs-actions-group">
+      <button class="mics-btn mics-btn-finish" ng-disabled="!canSave()" ng-click="done()">Done</button>
+      <button class="mics-btn mics-btn-cancel" ng-click="cancel()">Cancel</button>
+    </div>
+
+  </form>
+</div>

--- a/app/src/core/campaigns/external/edit-ad-group.html
+++ b/app/src/core/campaigns/external/edit-ad-group.html
@@ -33,32 +33,21 @@
         <div ng-include="'src/core/adgroups/choose-external-ads.html'"></div>
         <span>Select ads</span>
       </div>
-      <table class="fragment-list-creatives list-ads" ng-show="getAds(adGroup.id).length">
+      <table class="fragment-list-creatives list-ads" ng-show="ads.length">
         <thead>
         <tr>
-          <th>Size</th>
+          <th>Format</th>
           <th>Ad Name</th>
-          <th>Type</th>
-          <th>Url</th>
-          <th>Created</th>
+          <th>Technical Name</th>
           <th class="actions">Action</th>
         </tr>
         </thead>
         <tbody>
-        <tr ng-repeat="ad in getAds(adGroup.id)" fetch-creative="ad.creative_id as creative with rendererProperties">
-          <td>
-            <div class="mics-small-thumbnail">
-              <img creative-thumbnail="creative.id"/>
-              <div class="caption">
-                {{creative.format}}
-              </div>
-            </div>
-          </td>
-          <td>{{creative.name}}</td>
-          <td>{{creative.creative_type}}</td>
-          <td pretty-print-url="creativeProperties['destination_url'] | rendererProperty"></td>
-          <td>{{creative.creation_date|date:'shortDate'}}</td>
-          <td class="actions"><button class="mics-btn mics-btn-delete" ng-click="deleteAd(ad.id)">Remove</button></td>
+        <tr ng-repeat="ad in ads" fetch-creative="ad.creative_id as creative with rendererProperties">
+          <td>{{ad.format}}</td>
+          <td>{{ad.name}}</td>
+          <td>{{ad.technical_name}}</td>
+          <td class="actions"><button class="mics-btn mics-btn-delete" ng-click="deleteAd(ad)">Remove</button></td>
         </tr>
         </tbody>
       </table>

--- a/app/src/core/campaigns/external/edit-ad-group.html
+++ b/app/src/core/campaigns/external/edit-ad-group.html
@@ -5,8 +5,7 @@
       {{currentOrganisation}}
     </div>
     <div class="mcs-campaign-type ">
-      <img src="/images/plugins/multi-targeting-small.png"><br/>
-      <h4>Multi Targeting</h4>
+      <h4>External Campaign</h4>
     </div>
   </div>
 
@@ -33,7 +32,7 @@
         <div ng-include="'src/core/adgroups/choose-external-ads.html'"></div>
         <span>Select ads</span>
       </div>
-      <table class="fragment-list-creatives list-ads" ng-show="ads.length">
+      <table class="fragment-list-creatives list-ads" ng-show="creatives.length">
         <thead>
         <tr>
           <th>Format</th>
@@ -43,11 +42,11 @@
         </tr>
         </thead>
         <tbody>
-        <tr ng-repeat="ad in ads" fetch-creative="ad.creative_id as creative with rendererProperties">
-          <td>{{ad.format}}</td>
-          <td>{{ad.name}}</td>
-          <td>{{ad.technical_name}}</td>
-          <td class="actions"><button class="mics-btn mics-btn-delete" ng-click="deleteAd(ad)">Remove</button></td>
+        <tr ng-repeat="creative in creatives">
+          <td>{{creative.format}}</td>
+          <td>{{creative.name}}</td>
+          <td>{{creative.technical_name}}</td>
+          <td class="actions"><button class="mics-btn mics-btn-delete" ng-click="deleteAd(creative)">Remove</button></td>
         </tr>
         </tbody>
       </table>

--- a/app/src/core/campaigns/external/edit-campaign.html
+++ b/app/src/core/campaigns/external/edit-campaign.html
@@ -1,0 +1,49 @@
+<div class="mcs-default-container edit-campaign-external" ng-controller="core/campaigns/external/EditCampaignController">
+
+  <div class="mcs-default-sidebar">
+    <div class="organisation-name-block">
+      {{currentOrganisation}}
+    </div>
+    <div class="mcs-campaign-type ">
+      <img src="/images/plugins/multi-targeting-small.png"><br/>
+      <h4>Multi Targeting</h4>
+    </div>
+  </div>
+
+  <form role="form" class="mcs-default-edit-content mcs-full-page-form">
+
+    <!------------------------ Basic Info ------------------------>
+    <div class="mcs-default-heading">
+      <h1>Campaign</h1>
+    </div>
+
+    <!-- Name -->
+    <div mcs-form-group="" label-for="name" label-text="Campaign name">
+      <input ng-model="campaign.name" type="text" class="form-control input-lg" id="name">
+    </div>
+
+    <!-- Technical Name -->
+    <div mcs-form-group="" label-for="technical-name" label-text="Technical name">
+      <input ng-model="campaign.technical_name" type="text" class="form-control input-lg" id="technical-name">
+    </div>
+
+    <!------------------------ Select ad groups ------------------------>
+    <div class="mcs-form-group">
+      <div class="mics-block-heading">
+        <div class="btn-group">
+          <a class="mics-btn mics-btn-add" ng-click="newAdGroup()">Create new Ad Group</a>
+        </div>
+        <span>Ad groups</span>
+      </div>
+      <div ng-repeat="adGroup in adGroups|orderBy:'id'">
+        <div ng-include="'src/core/campaigns/external/view-ad-group.html'"></div>
+      </div>
+    </div>
+
+    <!-- Save or cancel -->
+    <div class="mcs-actions-group">
+      <button class="mics-btn mics-btn-finish" ng-click="save()">Save</button>
+      <button class="mics-btn mics-btn-cancel" ng-click="cancel()">Cancel</button>
+    </div>
+  </form>
+</div>

--- a/app/src/core/campaigns/external/edit-campaign.html
+++ b/app/src/core/campaigns/external/edit-campaign.html
@@ -5,8 +5,7 @@
       {{currentOrganisation}}
     </div>
     <div class="mcs-campaign-type ">
-      <img src="/images/plugins/multi-targeting-small.png"><br/>
-      <h4>Multi Targeting</h4>
+      <h4>External Campaign</h4>
     </div>
   </div>
 

--- a/app/src/core/campaigns/external/module.json
+++ b/app/src/core/campaigns/external/module.json
@@ -1,0 +1,17 @@
+{
+  "name": "core/campaigns/external",
+  "dependencies": [
+    "restangular",
+    "core/campaigns",
+    "core/creatives",
+    "core/adgroups",
+    "core/bidOptimizer",
+    "core/plugin",
+    "ui.bootstrap",
+    "core/keywords",
+    "core/placementlists",
+    "core/common/properties",
+    "core/common/ads",
+    "core/location"
+  ]
+}

--- a/app/src/core/campaigns/external/view-ad-group.html
+++ b/app/src/core/campaigns/external/view-ad-group.html
@@ -1,0 +1,70 @@
+<div class="show-ad-group">
+  <div class="btn-group pull-right">
+    <a ng-click="editAdGroup(adGroup)" class="mics-btn mics-btn-action">Edit</a>
+    <a ng-click="removeAdGroup(adGroup)" class="mics-btn mics-btn-delete">Delete</a>
+  </div>
+  <h4>{{adGroup.name}}</h4>
+
+  <div class="ad-group-components">
+    <div class="ad-group-component">
+      <h5>Ads <span class="badge">{{getAds(adGroup.id).length}}</span></h5>
+
+      <div class="ad-container">
+        <div class="thumbnail" ng-repeat="ad in getAds(adGroup.id)" fetch-creative="ad.creative_id as creative">
+          <div class="img-box">
+            <img creative-thumbnail="creative.id" creative-format="creative.format"/>
+          </div>
+          <div class="caption">
+            {{creative.format}}
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="ad-group-component">
+      <h5>Visibility : {{adGroup.visibility | constant:'adgroup_visibility'}}</h5>
+    </div>
+    <div
+        class="ad-group-component"
+        ng-show="adGroup.bid_optimizer_id"
+        fetch-bid-optimizer="adGroup.bid_optimizer_id as bidOptimizer"
+        fetch-plugin-from-version="bidOptimizer.engine_version_id as engine"
+        fetch-plugin-properties="engine.id as engineProperties"
+        >
+      <h5>
+        Bid Strategy :
+        {{bidOptimizer.name}} (
+        {{engineProperties['name'].value}}
+        by
+        {{engineProperties['provider'].value}}
+        ) - {{adGroup.bid_optimization_objective_type}} {{adGroup.bid_optimization_objective_value}} &euro;
+      </h5>
+    </div>
+    <div class="ad-group-component" ng-show="getAudienceSegments(adGroup.id).length">
+      <h5>Audience Segments <span class="badge">{{getAudienceSegments(adGroup.id).length}}</span></h5>
+
+      <div>
+        <span ng-repeat="segment in getAudienceSegments(adGroup.id)">
+        </span>
+      </div>
+    </div>
+    <div class="ad-group-component" ng-show="getKeywordLists(adGroup.id).length">
+      <h5>Keywords lists <span class="badge">{{getKeywordLists(adGroup.id).length}}</span></h5>
+
+      <div>
+        <span ng-repeat="keywordList in getKeywordLists(adGroup.id)">
+          <!-- {{keywordList.name}} -->
+        </span>
+      </div>
+    </div>
+    <div class="ad-group-component" ng-show="getPlacementLists(adGroup.id).length">
+      <h5>Placements <span class="badge">{{getPlacementLists(adGroup.id).length}}</span></h5>
+
+      <div>
+        <span ng-repeat="placement in getPlacementLists(adGroup.id)">
+          <!-- {{placement.name}}, exclude = {{placement.exclude}} -->
+        </span>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/app/src/core/campaigns/external/view-ad.html
+++ b/app/src/core/campaigns/external/view-ad.html
@@ -1,0 +1,7 @@
+<div>
+  <div class="btn-group pull-right">
+    <a ng-click="editAd(ad)" class="mics-btn mics-btn-action">Edit</a>
+    <a ng-click="removeAd(ad)" class="mics-btn mics-btn-delete">Delete</a>
+  </div>
+  <h4>{{ad.name}}</h4>
+</div>

--- a/app/src/core/campaigns/keywords/MainController.js
+++ b/app/src/core/campaigns/keywords/MainController.js
@@ -49,7 +49,7 @@ define(['./module'], function (module) {
         $scope.campaign.per_day_impression_capping = 10;
       }
 
-      CampaignPluginService.getCampaignEditor("com.mediarithmics.campaign.display", "keywords-targeting-template").then(function (template) {
+      CampaignPluginService.getCampaignEditor("com.mediarithmics.campaign.display", "keywords-targeting-editor").then(function (template) {
         // TODO load the campaign (no effect if already in cache or if this is a temporary id)
         if (!DisplayCampaignService.isInitialized() || DisplayCampaignService.getCampaignId() !== campaignId) {
           if (!campaignId || DisplayCampaignService.isTemporaryId(campaignId)) {

--- a/app/src/core/campaigns/module.json
+++ b/app/src/core/campaigns/module.json
@@ -5,6 +5,7 @@
     "core/location",
     "core/goals",
     "core/campaigns/expert",
+    "core/campaigns/external",
     "core/campaigns/keywords",
     "core/campaigns/emails",
     "core/campaigns/report",

--- a/app/src/core/campaigns/router.js
+++ b/app/src/core/campaigns/router.js
@@ -20,6 +20,16 @@ define(['./module'], function (module) {
           templateUrl: 'src/core/campaigns/expert/edit-ad-group.html',
           data: {navbar: 'src/core/layout/header/navbar/empty-navbar/empty-navbar.html'}
         })
+        .state('campaigns/display/external/edit', {
+          url: '/{organisation_id}/campaigns/display/external/edit/{campaign_id}',
+          templateUrl: 'src/core/campaigns/external/edit-campaign.html',
+          data: {navbar: 'src/core/layout/header/navbar/empty-navbar/empty-navbar.html'}
+        })
+        .state('campaigns/display/external/edit/campaign/edit-ad-group', {
+          url: '/{organisation_id}/campaigns/display/external/edit/:campaign_id/edit-ad-group/:ad_group_id',
+          templateUrl: 'src/core/campaigns/external/edit-ad-group.html',
+          data: {navbar: 'src/core/layout/header/navbar/empty-navbar/empty-navbar.html'}
+        })
         .state('campaigns/display', {
           url: '/{organisation_id}/campaigns/display',
           templateUrl: 'src/core/campaigns/list-display-campaigns.html',

--- a/app/src/core/scenarios/QuickCreateDisplayCampaignController.js
+++ b/app/src/core/scenarios/QuickCreateDisplayCampaignController.js
@@ -5,7 +5,7 @@ define(['./module'], function (module) {
     '$scope', '$uibModalInstance', '$document', '$log', 'core/campaigns/DisplayCampaignService', 'Restangular', 'core/common/auth/Session',
     'core/campaigns/CampaignPluginService',
     function ($scope, $uibModalInstance, $document, $log, DisplayCampaignService, Restangular, Session, CampaignPluginService) {
-      CampaignPluginService.getCampaignEditor("com.mediarithmics.campaign.display", "default-template").then(function (template) {
+      CampaignPluginService.getCampaignEditor("com.mediarithmics.campaign.display", "default-editor").then(function (template) {
         DisplayCampaignService.initCreateCampaign(template).then(function () {
           $scope.campaign = DisplayCampaignService.getCampaignValue();
         });


### PR DESCRIPTION
Clients need to be able to quickly add a campaign/ad_group/creative to use our platform alongside the advertising tools they already use.

Once merged remember to create the external-campaign-editor with the curls I provided by email.

MEDIARITHMICS/core-platform-services/pull/211