### PR TITLE
Improve user experience on the campaign dashboards.

### DIFF
--- a/app/src/core/campaigns/list-display-campaigns.html
+++ b/app/src/core/campaigns/list-display-campaigns.html
@@ -26,6 +26,9 @@
       <!-- Date picker -->
       <div class="col-md-6">
         <div class="campaign-list-date-controller pull-right">
+          <span ng-show="statisticsQuery.isRunning || exportQuery.isRunning">
+             <img src="./images/ajax-loader.gif" alt="computing..." class="inline-ajax-loader">
+          </span>
           <form class="form-inline pull-right" role="form">
             <input type="daterange" ng-model="reportDateRange" class="form-control range" format="L" ranges="reportDefaultDateRanges" opens="'left'">
           </form>

--- a/app/src/core/campaigns/report/show-report.html
+++ b/app/src/core/campaigns/report/show-report.html
@@ -41,6 +41,9 @@
                   <!--<li role="presentation"><a role="menuitem" tabindex="-1" ng-click="export('csv')">CSV</a></li>-->
                 </ul>
               </div>
+              <span ng-show="statisticsQuery.isRunning || exportQuery.isRunning" class="pull-right">
+                <img src="./images/ajax-loader.gif" alt="computing..." class="inline-ajax-loader">
+              </span>
             </div>
           </div>
         </div>

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1126,6 +1126,9 @@ form.mcs-full-page-form {
     position: absolute;
     left: 50%;
   }
+  .inline-ajax-loader {
+    margin-top: 3px;
+  }
 }
 
 .double-line-chart-selection {
@@ -1211,6 +1214,9 @@ div.mics-page-main-tabs {
         @extend .mics-table;
       }
     }
+  }
+  .inline-ajax-loader {
+    margin-top: 3px;
   }
 }
 


### PR DESCRIPTION
This commit fixes three things:
- running queries on stats display an image
- "invalidate" previous queries when the user resend them
- handle errors

The previous observed behavior was:
- display the first page
- change the time range
- wait
- see the stats appear and remember it's the first default request // **1**
- wait
- wait more
- hope it didn't silently stopped        // **2**
- see the second batch of stats updates

This commit fixes 1 and 2.