### PR TITLE
Fix build after jointjs update.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,11 @@
     "angular-nvd3": "~1.0.5",
     "tracekit": "^0.3.1",
     "angular-contenteditable": "~0.3.8",
-    "joint": "~0.9.7"
+    "joint": "~0.9.10",
+    "backbone": "1.2.3",
+    "dagre": "0.7.4",
+    "graphlib": "1.0.7",
+    "lodash": "3.10.1"
   },
   "devDependencies": {
     "angular-mocks": "1.3.15",


### PR DESCRIPTION
Joint removed the bower dependencies in clientIO/joint#223, leading to
a backbone file not found in our build. This commit adds the joint
dependencies as navigator dependencies.