### PR TITLE
Fix click_url on audited creatives.

### DIFF
--- a/app/src/core/common/properties/url-property.html
+++ b/app/src/core/common/properties/url-property.html
@@ -1,4 +1,4 @@
 <div mcs-form-group="" label-for="property-{{property.id}}" label-text="{{property.technical_name}}">
-    <input class="form-control" ng-disabled="ngdisabled" ng-model="property.value.url" type="url" id="property-{{property.id}}">
+    <input class="form-control" ng-disabled="ngDisabled" ng-model="property.value.url" type="url" id="property-{{property.id}}">
     <span id="helpBlock" class="help-block" ><span pretty-print-url="property.value.url" ></span></span>
     </div>


### PR DESCRIPTION
There was a typo on the property name, the click_url field was never
disabled (`ngDisabled` is declared [here](https://github.com/MEDIARITHMICS/mediarithmics-navigator/blob/9f484782e5742e6502a58a431001e5f9a8bd222d/app/src/core/common/properties/propertiesDirectives.js#L35)).