### PR TITLE
Persist feed session with active status

### DIFF
--- a/app/src/core/datamart/segments/EditOneController.js
+++ b/app/src/core/datamart/segments/EditOneController.js
@@ -86,7 +86,18 @@ define(['./module'], function (module) {
           $scope.segment.query_id = queryId;
           promise = Restangular.all('audience_segments').post($scope.segment, {organisation_id: Session.getCurrentWorkspace().organisation_id});
         }
-
+        function updateActivationStatusIfNeeded(promise, activation) {
+          if(activation.value.id === undefined && activation.value.status === 'ACTIVE') {
+            return promise.then(function() {
+                $log.info("start activation", activation);
+                activation.value.status = 'ACTIVE';
+                return activation.save();
+            });
+          } else {
+            return promise;
+          }
+          
+        }
         promise.then(function(audienceSegment) {
           var promises = [];
           if($scope.activations) {
@@ -95,9 +106,9 @@ define(['./module'], function (module) {
               var p = activation.save();
               promises.push(p);
             }
-            return $q.all(promises).then(function(){
+            return updateActivationStatusIfNeeded($q.all(promises).then(function(){
               return audienceSegment;
-            });
+            }), activation);
           } else {
             return audienceSegment;
           }

--- a/app/src/core/datamart/segments/EditOneController.js
+++ b/app/src/core/datamart/segments/EditOneController.js
@@ -104,11 +104,11 @@ define(['./module'], function (module) {
             for(var i=0; i < $scope.activations.length; i++) {
               var activation = $scope.activations[i];
               var p = activation.save();
-              promises.push(p);
+              promises.push(updateActivationStatusIfNeeded(p, activation));
             }
-            return updateActivationStatusIfNeeded($q.all(promises).then(function(){
+            return $q.all(promises).then(function(){
               return audienceSegment;
-            }), activation);
+            });
           } else {
             return audienceSegment;
           }


### PR DESCRIPTION
When persisting for the first time an external feed, the backend will force its
status to "PAUSED", because it's not possible to configure properties without
saving an instance of external feed.

In order to workaround this behavior, navigator will update the status after 
saving properties

Related to https://github.com/MEDIARITHMICS/core-platform-services/pull/234