### PR TITLE
popover / badges fix

### DIFF
--- a/app/src/core/campaigns/report/show-report.html
+++ b/app/src/core/campaigns/report/show-report.html
@@ -137,15 +137,15 @@
                     <td>
                       <div mics-ad-status="ad" ad-group="findAdGroup(ad.id)" campaign="campaign"></div>
                       <span class="badge creative-audit-notification-warning"
-                            popover="The creative has the status {{ad.creative_audit_status}}"
+                            uib-popover="The creative has the status {{ad.creative_audit_status}}"
                             popover-trigger="mouseenter"
                             ng-if="ad.creative_audit_status == 'NOT_AUDITED'">?</span>
                       <span class="badge creative-audit-notification-warning"
-                            popover="The creative has the status {{ad.creative_audit_status}} and will be used as soon as the audit ends."
+                            uib-popover="The creative has the status {{ad.creative_audit_status}} and will be used as soon as the audit ends."
                             popover-trigger="mouseenter"
                             ng-if="ad.creative_audit_status == 'AUDIT_PENDING'">?</span>
                       <span class="badge creative-audit-notification-alert"
-                            popover="One or more audits failed, this creative may not be used everywhere !"
+                            uib-popover="One or more audits failed, this creative may not be used everywhere !"
                             popover-trigger="mouseenter"
                             ng-if="ad.creative_audit_status == 'AUDIT_FAILED' || ad.creative_audit_status == 'AUDIT_PARTIALLY_PASSED'">!</span>
                     </td>

--- a/app/src/core/settings/sites/edit.one.html
+++ b/app/src/core/settings/sites/edit.one.html
@@ -22,7 +22,7 @@
         <div class="col-xs-3">
           <div mcs-form-group="full">
             <label for="token">Token
-              <span class="badge" popover="A unique random identifier (e.g. ABCD123)" popover-trigger="mouseenter" popover-placement="right">?</span>
+              <span class="badge" uib-popover="A unique random identifier (e.g. ABCD123)" popover-trigger="mouseenter" popover-placement="right">?</span>
             </label>
             <input class="form-control input-md" ng-model="site.token" type="text" id="token">
           </div>

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1238,7 +1238,7 @@ div.mics-page-main-tabs {
   }
   .badge {
     background-color: #ffffff;
-    color: #00a1e1;
+    color: $mcs-light-blue;
     font-size: 12px;
   }
 }
@@ -1314,6 +1314,7 @@ div.mics-page-main-tabs {
 
     .badge {
       @include use-normal-font();
+      color: white;
       background: $mcs-red;
       font-size: $font-size-base;
       padding: 5px 8px;


### PR DESCRIPTION
This pull request fixes two things:

- some forgotten popover (on the campaign report, when a creative is not audited)
- the color of badges (when editing a campaign)