### PR TITLE
Add support for the script tag creatives.

### DIFF
--- a/app/src/core/creatives/plugins/display-ad/common/CommonEditController.js
+++ b/app/src/core/creatives/plugins/display-ad/common/CommonEditController.js
@@ -15,6 +15,8 @@ define(['./module'], function (module) {
           return "";
         }
         switch (displayAd.renderer_group_id + "/" + displayAd.renderer_artifact_id) {
+          case "com.mediarithmics.creative.display/image-script":
+            return "Image Banner";
           case "com.mediarithmics.creative.display/image-iframe":
             return "Image Banner";
           case "com.mediarithmics.creative.display/flash-iframe":

--- a/app/src/core/creatives/plugins/display-ad/default-editor/create.html
+++ b/app/src/core/creatives/plugins/display-ad/default-editor/create.html
@@ -19,6 +19,7 @@
         </div>
 
         <label><input type="radio" name="artifactId" ng-model="wrapper.artifactId" value="image-iframe"> Image file (.png, .jpg, .gif)</label><br>
+        <label><input type="radio" name="artifactId" ng-model="wrapper.artifactId" value="image-script"> Image file (.png, .jpg, .gif), for skins</label><br>
         <label><input type="radio" name="artifactId" ng-model="wrapper.artifactId" value="flash-iframe"> Flash file (.swf)</label><br>
         <label><input type="radio" name="artifactId" ng-model="wrapper.artifactId" value="dynamic-template"> Dynamic template</label><br>
         <label><input type="radio" name="artifactId" ng-model="wrapper.artifactId" value="external-display-ad-renderer">External ad server</label><br>


### PR DESCRIPTION
The new ad renderer (with a string tag type) was supported by the API
but not by the UI.