### PR TITLE
Default value for bid_optimization_objective_type.

### DIFF
--- a/app/src/core/campaigns/expert/EditAdGroupController.js
+++ b/app/src/core/campaigns/expert/EditAdGroupController.js
@@ -103,6 +103,7 @@ define(['./module'], function (module) {
           $scope.adGroup.bid_optimizer_id = null;
         } else {
           $scope.adGroup.bid_optimizer_id = params.bidOptimizer.id;
+          $scope.adGroup.bid_optimization_objective_type = $scope.adGroup.bid_optimization_objective_type || "CPC";
         }
       });
 


### PR DESCRIPTION
Sending `null` to the backend won't work, defaulting to `CPC` sounds
like a good option.