### PR TITLE
Datafile: add upload support.

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -32,8 +32,7 @@ require.config({
         "autofill-event": "../bower_components/autofill-event/src/autofill-event",
 
         "async": "../bower_components/async/lib/async",
-        "moxie": "../bower_components/plupload/js/moxie",
-        "plupload": "../bower_components/plupload/js/plupload.dev",
+        "plupload": "../bower_components/plupload/js/plupload",
         "tracekit": "../bower_components/tracekit/tracekit",
 
 
@@ -78,7 +77,7 @@ require.config({
         'ngBootstrap': ['angular', 'bootstrap', 'jqDaterangepicker'],
         'ui': ['angular'],
         'ngTable': ['angular'],
-        'plupload': {deps: ['moxie'], exports: 'plupload'},
+        'plupload': {exports: 'plupload'},
         'ui.router': ['angular'],
         'ui.router.extras': ['angular', 'ui.router'],
         'ngload': ['angularAMD'],

--- a/app/src/core/common/plupload.js
+++ b/app/src/core/common/plupload.js
@@ -162,6 +162,7 @@ define(['./module', "plupload"], function (module) {
           uploader.bind('FileUploaded', handleFileUploaded);
           uploader.bind('UploadComplete', handleUploadComplete);
           uploader.bind('BeforeUpload', function (uploader) {
+            uploader.setOption("url", scope.micsPlUpload.url);
             uploader.settings.url = scope.micsPlUpload.url;
           });
           uploader.init();

--- a/app/src/core/common/properties/data-file-property.html
+++ b/app/src/core/common/properties/data-file-property.html
@@ -1,12 +1,10 @@
 <div mcs-form-group="" label-for="property-uri-{{property.id}}" label-text="{{property.technical_name}} URI">
       <input class="form-control " ng-disabled="ngDisabled" ng-model="property.value.uri" type="text" id="property-uri-{{property.id}}" />
       <br/>
-<!--
       <div mics-pl-upload="micsPlUpload" ng-if="micsPlUpload">
-           <a class="browse-button mics-btn mics-btn-add" ng-click="upload(property.value.uri)" >Upload</a>
+           <button class="browse-button mics-btn mics-btn-add" ng-disabled="isNotValid(property.value.uri)" ng-show="property.value.uri">Upload and overwrite</button>
+           <a class="mics-btn mics-btn-delete" ng-click="download(property.value.uri)" ng-disabled="isNotValid(property.value.uri)" >Download File</a>
       </div>
--->
-      <a class="mics-btn mics-btn-delete" ng-click="download(property.value.uri)" ng-disabled="isNotValid(property.value.uri)" >Download File</a>
 
 </div>
 <div mcs-form-group="" label-for="property-last-modified-{{property.id}}" label-text="{{property.technical_name}} last modified date">

--- a/app/src/core/common/properties/propertiesDirectives.js
+++ b/app/src/core/common/properties/propertiesDirectives.js
@@ -274,32 +274,33 @@ define(['./module'], function (module) {
         templateUrl: '/src/core/common/properties/data-file-property.html',
         link: function (scope, element, attrs) {
 
-         /* scope.micsPlUpload = {
-                  multi_selection: true,
-                  url: Restangular.one("data_file").one("data?uri=" + scope.uriUpload).getRestangularUrl() + "&access_token=" + encodeURIComponent(AuthenticationService.getAccessToken()),
-                  upload_method:"put",
-                  filters: {
-                    mime_types: [],
-                    max_file_size: "2500kb"
-                  },
-                  init: {
-                    FileUploaded: function () {
-                      waitingService.hideWaitingModal();
-                    },
-                    FilesAdded: function () {
-                      waitingService.showWaitingModal();
-                      scope.uploadError = null;
-                      scope.$apply();
-                    },
-                    Error: function (up, err) {
-                      waitingService.hideWaitingModal();
-                      scope.uploadError = err.message;
-                      scope.$apply();
-                    }
-                  }
-                };*/
-          scope.$watch("property", function () {
-//            console.log(scope.property);
+          scope.micsPlUpload = {
+            multi_selection: false,
+            url: $location.protocol() + ":" + Restangular.one("data_file").one("data").getRestangularUrl()+ "?uri=" + encodeURIComponent(scope.property.value.uri),
+            http_method: "PUT",
+            multipart: false,
+            filters: {
+              max_file_size: "2500kb"
+            },
+            init: {
+              FileUploaded: function () {
+                waitingService.hideWaitingModal();
+              },
+              FilesAdded: function () {
+                waitingService.showWaitingModal();
+                scope.uploadError = null;
+                scope.$apply();
+              },
+              Error: function (up, err) {
+                waitingService.hideWaitingModal();
+                scope.uploadError = err.message;
+                scope.$apply();
+              }
+            }
+          };
+
+          scope.$watch("property.value.uri", function () {
+           scope.micsPlUpload.url = $location.protocol() + ":" + Restangular.one("data_file").one("data").getRestangularUrl()+ "?uri=" + encodeURIComponent(scope.property.value.uri);
           });
 
           scope.isNotValid = function(uri){
@@ -312,12 +313,6 @@ define(['./module'], function (module) {
               $window.location = dlUrl;
             }
           };
-          // We are using plupload 2.1, and this version do not allow to upload with a put method
-          // TODO upgrade to plupload 3 and uncomment the code
-          /*scope.upload = function(uri){
-            scope.micsPlUpload.uri = Restangular.one("data_file").one("data?uri=" + uri).getRestangularUrl() + "&access_token=" + encodeURIComponent(AuthenticationService.getAccessToken())
-            scope.uriUpload =uri;
-          };*/
         }
       };
     }

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "angular-bootstrap": "1.1.*",
     "restangular": "1.4.0",
     "async": "0.2.10",
-    "plupload": "2.1.8",
+    "plupload": "v3.0-beta1",
     "bootstrap-sass": "git://github.com/twbs/bootstrap-sass.git#~3.3.6",
     "ng-bs-daterangepicker": "https://github.com/sagivf/ng-bs-daterangepicker.git#05d8efaa7ea6b04cc9f875cf9ebef522dff3d376",
     "bootstrap-daterangepicker": "1.3.9",


### PR DESCRIPTION
This is a simple upload popup, without any path selection.
The `http_method` method has been added on plupload in the
v3-beta1 version (released), and on the v2 branch (not yet released).