### PR TITLE
Fix deployed version.

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -32,7 +32,7 @@ require.config({
         "autofill-event": "../bower_components/autofill-event/src/autofill-event",
 
         "async": "../bower_components/async/lib/async",
-        "plupload": "../bower_components/plupload/js/plupload",
+        "plupload": "../bower_components/plupload/js/plupload.min",
         "tracekit": "../bower_components/tracekit/tracekit",
 
 

--- a/prod.sh
+++ b/prod.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+[[ -f ~/.nvm/nvm.sh ]] && source ~/.nvm/nvm.sh
+
 set -e
 # Any subsequent(*) commands which fail will cause the shell script to exit immediately
 npm update


### PR DESCRIPTION
My best guess at what's happening: plupload.js contains a `require`
function and it messes with r.js, uglify or both. Loading
plupload.min.js works, so... here it is.