### PR TITLE
Fix quick upload

### DIFF
--- a/app/src/core/creatives/plugins/display-ad/basic-editor/UploadCreativeController.js
+++ b/app/src/core/creatives/plugins/display-ad/basic-editor/UploadCreativeController.js
@@ -12,8 +12,10 @@ define(['./module'], function (module) {
       };
 
       $scope.step = 'step0';
-      $scope.destination_domain = null;
-      $scope.url = null;
+      $scope.params = {
+        url: null,
+        destination_domain: null
+      };
       // For the page
       $scope.newCreativesWrapper = [];
 
@@ -49,6 +51,10 @@ define(['./module'], function (module) {
         }
       });
 
+      $scope.canFinalizeCreation = function () {
+        return !!$scope.params.url && !!$scope.params.destination_domain;
+      };
+
       function saveCreativeWrapper(userDefinedCreative) {
         var isFlash = userDefinedCreative.asset.mime_type === "application/x-shockwave-flash";
         var options = {
@@ -68,9 +74,9 @@ define(['./module'], function (module) {
 
         creativeContainer.value.name = userDefinedCreative.creative.name;
         creativeContainer.value.format = userDefinedCreative.asset.width + "x" + userDefinedCreative.asset.height;
-        creativeContainer.value.destination_domain = $scope.destination_domain;
+        creativeContainer.value.destination_domain = $scope.params.destination_domain;
         creativeContainer.value.subtype = "BANNER";
-        creativeContainer.getOrCreatePropertyValueByTechnicalName("destination_url").value = {"url": $scope.url};
+        creativeContainer.getOrCreatePropertyValueByTechnicalName("destination_url").value = {"url": $scope.params.url};
         if (isFlash) {
           creativeContainer.getOrCreatePropertyValueByTechnicalName("flash").value = {"asset_id": userDefinedCreative.asset.id};
         } else {
@@ -87,6 +93,11 @@ define(['./module'], function (module) {
       }
 
       $scope.done = function() {
+
+        if (!$scope.canFinalizeCreation()) {
+          return;
+        }
+
         var promises = _.map($scope.newCreativesWrapper, saveCreativeWrapper);
 
         $q.all(promises).then(function () {

--- a/app/src/core/creatives/plugins/display-ad/basic-editor/edit.html
+++ b/app/src/core/creatives/plugins/display-ad/basic-editor/edit.html
@@ -24,7 +24,7 @@
       <!-- Format -->
       <div class="col-md-4">
         <div mcs-form-group="full" label-for="format" label-text="Format">
-          <select ng-disabled="disabledEdition" ng-model="displayAd.format" ng-options="iabAdSize for iabAdSize in iabAdSizes" id="format"></select>
+          <select ng-disabled="disabledEdition" ng-model="displayAd.format" required ng-options="iabAdSize for iabAdSize in iabAdSizes" id="format"></select>
         </div>
       </div>
     </div>
@@ -32,7 +32,7 @@
     <div class="row">
       <div class="col-md-8">
         <div mcs-form-group="full" label-for="destination_dom" label-text="Destination domain">
-          <input ng-disabled="disabledEdition" ng-model="displayAd.destination_domain" type="text" class="form-control input" id="destination_dom" pattern="^([a-zA-Z0-9][-a-zA-Z0-9]*[a-zA-Z0-9]\.)+([a-zA-Z0-9]{2,})$">
+          <input ng-disabled="disabledEdition" ng-model="displayAd.destination_domain" required type="text" class="form-control input" id="destination_dom" pattern="^([a-zA-Z0-9][-a-zA-Z0-9]*[a-zA-Z0-9]\.)+([a-zA-Z0-9]{2,})$">
             <span id="helpBlock" class="help-block">This is the final redirect location domain (without http or params) <br/>
                 eg: destination.mybrand.com</span>
         </div>
@@ -52,11 +52,10 @@
       <div class="col-md-12">
         <h3>Properties</h3>
         <div mcs-form-group="" label-for="destinationUrlProperty-{{destinationUrlProperty.id}}" label-text="Destination URL" ng-show="destinationUrlProperty">
-          <input class="form-control" ng-disabled="ngdisabled" ng-model="destinationUrlProperty.value.url" type="url" id="destinationUrlProperty-{{destinationUrlProperty.id}}">
+          <input class="form-control" ng-disabled="disabledEdition" required ng-model="destinationUrlProperty.value.url" type="url" id="destinationUrlProperty-{{destinationUrlProperty.id}}">
           <span id="helpBlock" class="help-block">This is the URL where the user will be redirected to.
           If you use a click tracker, please check the box and fill the final destination domain.
           Otherwise, you may experience blocking on some ad exchanges.<br/>
-          <span ng-show="isFinalUrl">Currently <strong>{{$parent.$parent.displayAd.destination_domain}}</strong></span>
           </span>
         </div>
       </div>
@@ -83,9 +82,9 @@
     </div>
     <!-- save or cancel -->
     <div class="mcs-actions-group">
-      <button class="mics-btn mics-btn-finish" ng-click="save(disabledEdition)">Done</button>
-      <button ng-if="!disabledEdition || !form.$valid" class="mics-btn mics-btn-finish" ng-click="saveAndRefresh()">Save &amp; Refresh</button>
-      <button ng-if="!disabledEdition || !form.$valid" class="mics-btn mics-btn-cancel" ng-click="cancel()">Cancel</button>
+      <button ng-disabled="!form.$valid" class="mics-btn mics-btn-finish" ng-click="save(disabledEdition)">Done</button>
+      <button ng-disabled="!form.$valid" ng-if="!disabledEdition" class="mics-btn mics-btn-finish" ng-click="saveAndRefresh()">Save &amp; Refresh</button>
+      <button class="mics-btn mics-btn-cancel" ng-click="cancel()">Cancel</button>
     </div>
   </form>
 </div>

--- a/app/src/core/creatives/plugins/display-ad/basic-editor/upload-creative.html
+++ b/app/src/core/creatives/plugins/display-ad/basic-editor/upload-creative.html
@@ -10,11 +10,11 @@
 
     <div ng-show="newCreativesWrapper.length && step == 'step2'">
       <div mcs-form-group="" label-for="name" label-text="Destination domain">
-        <input ng-model="$parent.$parent.destination_domain" type="text" class="form-control input" id="destination_dom" pattern="^([a-zA-Z0-9][-a-zA-Z0-9]*[a-zA-Z0-9]\.)+([a-zA-Z0-9]{2,})$"/>
+        <input ng-model="params.destination_domain" required type="text" class="form-control input" id="destination_dom" pattern="^([a-zA-Z0-9][-a-zA-Z0-9]*[a-zA-Z0-9]\.)+([a-zA-Z0-9]{2,})$"/>
         <span id="helpBlock" class="help-block">This is the final redirect location domain (without http or params)<br/>eg: destination.mybrand.com</span>
       </div>
       <div mcs-form-group="" label-for="destinationUrlProperty" label-text="Destination URL">
-        <input class="form-control" ng-model="url" type="url" id="destinationUrlProperty">
+        <input class="form-control" required ng-model="params.url" type="url" id="destinationUrlProperty">
             <span id="helpBlock" class="help-block">
                 This is the URL where the user will be redirected to. You may use a click tracker.
                 <br/> eg: http://redirect.to/mypage
@@ -34,6 +34,6 @@
   <div class="modal-footer">
     <a ng-click="cancel()" class="mics-btn mics-btn-cancel">Cancel</a>
     <a ng-show="step == 'step1'" class="mics-btn mics-btn-finish" ng-click="next()">Next</a>
-    <a ng-show="step == 'step2'" ng-click="done()" class="mics-btn mics-btn-finish">Done</a>
+    <a ng-show="step == 'step2'" ng-click="done()" ng-disabled="!canFinalizeCreation()" class="mics-btn mics-btn-finish">Done</a>
   </div>
 </div>

--- a/app/src/core/creatives/plugins/display-ad/default-editor/edit.html
+++ b/app/src/core/creatives/plugins/display-ad/default-editor/edit.html
@@ -24,7 +24,7 @@
       <!-- Format -->
       <div class="col-md-4">
         <div mcs-form-group="full" label-for="format" label-text="Format">
-          <select ng-disabled="disabledEdition" ng-model="displayAd.format" ng-options="iabAdSize for iabAdSize in iabAdSizes" id="format"></select>
+          <select ng-disabled="disabledEdition" ng-model="displayAd.format" required ng-options="iabAdSize for iabAdSize in iabAdSizes" id="format"></select>
         </div>
       </div>
     </div>
@@ -32,8 +32,9 @@
     <div class="row">
       <div class="col-md-8">
         <div mcs-form-group="full" label-for="destination_dom" label-text="Destination domain">
-          <input ng-disabled="disabledEdition" ng-model="displayAd.destination_domain" type="text" class="form-control input" id="destination_dom" pattern="^([a-zA-Z0-9][-a-zA-Z0-9]*[a-zA-Z0-9]\.)+([a-zA-Z0-9]{2,})$">
-          <span id="helpBlock" class="help-block">This is the final redirect location domain (without http or params)<br/>eg: destination.mybrand.com</span>
+          <input ng-disabled="disabledEdition" ng-model="displayAd.destination_domain" required type="text" class="form-control input" id="destination_dom" pattern="^([a-zA-Z0-9][-a-zA-Z0-9]*[a-zA-Z0-9]\.)+([a-zA-Z0-9]{2,})$">
+            <span id="helpBlock" class="help-block">This is the final redirect location domain (without http or params) <br/>
+                eg: destination.mybrand.com</span>
         </div>
       </div>
     </div>
@@ -64,9 +65,9 @@
     </div>
     <!-- save or cancel -->
     <div class="mcs-actions-group">
-      <button class="mics-btn mics-btn-finish" ng-click="save(disabledEdition)">Done</button>
-      <button ng-disabled="disabledEdition || !form.$valid" class="mics-btn mics-btn-finish" ng-click="saveAndRefresh()">Save &amp; Refresh</button>
-      <button ng-disabled="disabledEdition || !form.$valid" class="mics-btn mics-btn-cancel" ng-click="cancel()">Cancel</button>
+      <button ng-disabled="!form.$valid" class="mics-btn mics-btn-finish" ng-click="save(disabledEdition)">Done</button>
+      <button ng-disabled="!form.$valid" ng-if="!disabledEdition" class="mics-btn mics-btn-finish" ng-click="saveAndRefresh()">Save &amp; Refresh</button>
+      <button class="mics-btn mics-btn-cancel" ng-click="cancel()">Cancel</button>
     </div>
   </form>
 </div>

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -287,7 +287,7 @@ label {
   }
 }
 
-input.ng-invalid {
+input.ng-invalid, select.ng-invalid {
   border-color: $brand-danger !important;
 }
 


### PR DESCRIPTION
When a user creates a quick upload banner, the destination url wasn't
copied over and was lost. This commit fixes that and force the user to
set the destination domain / destination url before saving the creative.