### PR TITLE
Add a warning for http tags.

### DIFF
--- a/app/src/core/creatives/plugins/display-ad/default-editor/EditController.js
+++ b/app/src/core/creatives/plugins/display-ad/default-editor/EditController.js
@@ -71,6 +71,18 @@ define(['./module'], function (module) {
         DisplayAdService.reset();
         $location.path(Session.getWorkspacePrefixUrl() + '/creatives/display-ad');
       };
+
+      $scope.findWarnings = function (propertyContainer) {
+        var property = propertyContainer.value;
+        var warnings = [];
+        switch(property.technical_name) {
+          case "tag":
+            if (property.value && property.value.value && property.value.value.substr(0, 7) === "http://") {
+              warnings.push("The tag isn't in https, the creative will not be displayed on secured websites.");
+            }
+        }
+        return warnings;
+      };
     }
   ]);
 });

--- a/app/src/core/creatives/plugins/display-ad/default-editor/edit.html
+++ b/app/src/core/creatives/plugins/display-ad/default-editor/edit.html
@@ -60,6 +60,17 @@
           <mcs-text-property ng-disabled="disabledEdition || property.value.origin == 'PLUGIN_STATIC'" property="property.value" ng-if="property.value.property_type == 'STRING'"></mcs-text-property>
           <mcs-ad-layout-property ng-disabled="disabledEdition || property.value.origin == 'PLUGIN_STATIC'" plugin-id="displayAd.renderer_plugin_id" plugin-version-id="displayAd.renderer_version_id" property="property.value" organisation-id="organisationId" ng-if="property.value.property_type == 'AD_LAYOUT'"></mcs-ad-layout-property>
           <mcs-style-sheet-property ng-disabled="disabledEdition || property.value.origin == 'PLUGIN_STATIC'" property="property.value" organisation-id="organisationId" ng-if="property.value.property_type == 'STYLE_SHEET'"></mcs-style-sheet-property>
+
+          <div ng-repeat="warning in findWarnings(property)">
+            <div class="mcs-form-row">
+              <div class="mcs-form-group mcs-form-group-default">
+                <p class="alert alert-warning">
+                {{warning}}
+                </p>
+              </div>
+            </div>
+          </div>
+
         </div>
       </div>
     </div>


### PR DESCRIPTION
This is a common pitfall: the http tag breaks the https audit and causes
some headaches as the root cause is not explicit.

This commit adds a warning about this situation.