### PR TITLE
Increase the number of fetched creatives.

### DIFF
--- a/app/src/core/creatives/DisplayAdListController.js
+++ b/app/src/core/creatives/DisplayAdListController.js
@@ -17,7 +17,7 @@ define(['./module'], function (module) {
       // Archived
       $scope.displayArchived = false;
       var options = {
-        max_results: 200,
+        max_results: 300,
         organisation_id: Session.getCurrentWorkspace().organisation_id,
         creative_type: 'DISPLAY_AD'
       };


### PR DESCRIPTION
We don't have real pagination on the creative list and 200 creatives is
not enough. The immediate dirty fix is to increase this limit, the real
fix (we will work on it as soon as we have enough time) would be to
use server side pagination.