### PR TITLE
Fix build in node v6

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -6,7 +6,6 @@
   "eqeqeq": true,
   "immed": true,
   "indent": 2,
-  "latedef": true,
   "newcap": true,
   "noarg": true,
   "regexp": true,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-htmlmin": "~0.1.3",
     "grunt-contrib-imagemin": "~0.3.0",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-requirejs": "^0.4.4",
     "grunt-contrib-uglify": "~0.9.0",
     "grunt-contrib-watch": "~0.5.2",


### PR DESCRIPTION
The `latedef` option was never used, only JSHint 2.9+ supports it (the
previous version was 2.5) so I removed it (it generated a lot of
errors).