### PR TITLE
Fix deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-google-cdn": "~0.2.0",
     "grunt-karma": "0.8.2",
     "grunt-newer": "~0.5.4",
-    "grunt-nexus-deployer": "0.0.4",
+    "grunt-nexus-deployer": "0.2.0",
     "grunt-ngmin": "~0.0.2",
     "grunt-rev": "~0.1.0",
     "grunt-shell": "^0.7.0",


### PR DESCRIPTION
With node6 and the old `grunt-nexus-deployer` version, I got invalid
sha1. Updating this package fixed the issue.