### PR TITLE
Increase the number of fetched creatives.

### DIFF
--- a/app/angular/src/core/adgroups/ChooseExistingAdsController.js
+++ b/app/angular/src/core/adgroups/ChooseExistingAdsController.js
@@ -15,7 +15,7 @@ define(['./module'], function (module) {
       }
 
       $scope.availableCreatives = Restangular.all("creatives").getList({
-        max_results : 300,
+        max_results : 1000,
         creative_type : creativeType,
         archived : false,
         organisation_id : Session.getCurrentWorkspace().organisation_id

--- a/app/angular/src/core/creatives/DisplayAdListController.js
+++ b/app/angular/src/core/creatives/DisplayAdListController.js
@@ -17,7 +17,7 @@ define(['./module'], function (module) {
       // Archived
       $scope.displayArchived = false;
       var options = {
-        max_results: 300,
+        max_results: 1000,
         organisation_id: Session.getCurrentWorkspace().organisation_id,
         creative_type: 'DISPLAY_AD'
       };


### PR DESCRIPTION
The real pagination on the creative list is still a work in progress
and 300 creatives is not enough. The immediate dirty fix is to increase
this limit.